### PR TITLE
Adding Makefile to automate analysis and help reproducibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all: data/fall2020_extractions.txt
+
+# Dialogue extractions from Zoom transcripts from the Fall 2020 ASIST
+# experiment
+data/fall2020_extractions.txt: scripts/run_fall2020_analysis
+	$< $@

--- a/scripts/run_fall2020_analysis
+++ b/scripts/run_fall2020_analysis
@@ -5,9 +5,10 @@ set -euo pipefail
 # Set the ROOTDIR environment variable, assuming that the directory structure
 # mirrors that of the git repository.
 ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" >/dev/null 2>&1 && pwd)"
+
+OUTPUT_FILE=$1
 GCS_DIR=study-1_2020.08
 DATA_DIR="$ROOTDIR"/data/$GCS_DIR
-OUTPUT_FILE="output_events.txt"
 EXPERIMENT_ID=f7f3f5b6-835d-4523-8f79-68fd5199ae89
 
 pushd $ROOTDIR


### PR DESCRIPTION
This PR adds a Makefile to help with automation and reproducibility. Running `make` will produce the file `data/fall2020_extractions.txt` which contains extractions from the Fall 2020 ASIST Zoom transcripts (one JSON object per line).