### PR TITLE
Output topic change + gitlab deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ expected to have the following format:
 
 ### Output 
 
-Message bus topic: `agent/tomcat_chatbot`
+Message bus topic: `agent/dialog`
 
 The Dialog Agent will publish its analysis to the message bus in [chat_analysis_message][1] format.
 

--- a/scripts/deploy_to_gitlab
+++ b/scripts/deploy_to_gitlab
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# This script builds the dialog agent image and deploys it to the Aptima Gitlab
+# instance.
+
+docker login gitlab.asist.aptima.com:5050
+docker build -t gitlab.asist.aptima.com:5050/asist/testbed/uaz_dialog_agent .
+docker push gitlab.asist.aptima.com:5050/asist/testbed/uaz_dialog_agent

--- a/src/main/scala/org/clulab/asist/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/DialogAgentMqtt.scala
@@ -22,7 +22,7 @@ object DialogAgentMqttDefaults {
   val TOPIC_INPUT_ASR: String = "agent/asr"
 
   /** publish input analysis to this message bus topic */
-  val TOPIC_OUTPUT: String = "agent/tomcat_chatbot"
+  val TOPIC_OUTPUT: String = "agent/dialog"
 }
 
 /** Message bus connectivity for dialog agents */


### PR DESCRIPTION
This PR changes the output publishing topic to `agent/dialog` and adds a script to deploy the built image to the Aptima Gitlab container registry.