### PR TITLE
Metadata2tsv and sync_asist_data updates

### DIFF
--- a/scripts/metadata2tsv
+++ b/scripts/metadata2tsv
@@ -1,35 +1,98 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python
 
 # metadata2tsv
 # ============
 # This script processes one or more .metadata files (corresponding to dumps of
 # message data from the message bus) and prints a tabular (TSV) representation
-# of the ASR messages published on the 'agent/asr/topic' contained in  the
+# of the ASR messages published on the 'agent/asr/final' topic contained in the
 # files.
 
-# Prerequisites
-# -------------
-# You will need the 'jq' program (https://stedolan.github.io/jq/) to run this
-# script. You can install it using your OS package manager.
-# 
-# - macOS
-#   - MacPorts: port install jq
-#   - Homebrew: brew install jq
-# - Ubuntu
-#   - apt-get install jq
-#
 # Example usage
 # -------------
 #
 #   ./metadata2tsv myDirectory/*.metadata > output.tsv
-#
-# The invocation above will process all the files ending with .metadata in
-# 'myDirectory', and create a TSV file named 'output.tsv', with the following
-# four columns:
-# - Trial ID
-# - ISO-8601 Timestamp
-# - Participant ID
-# - Text of the message
 
-grep -h "agent/asr/final" $@ \
-    | jq -r '[.msg.trial_id, .msg.timestamp, .data.participant_id, .data.text] | @tsv'
+
+import sys
+import json
+from pathlib import Path
+from dateutil.parser import parse
+from dateutil.relativedelta import relativedelta
+from logging import warning
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+
+    parser = ArgumentParser(
+        description="metadata2tsv",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "input", type=str, nargs="+", help="Input .metadata files"
+    )
+    args = parser.parse_args()
+
+    print(
+        "\t".join(
+            (
+                "Team",
+                "Trial",
+                "CondBtwn",
+                "CondWin",
+                "timestamp",
+                "relative_timestamp (mm:ss)",
+                "participant_id",
+                "text",
+            )
+        )
+    )
+
+    for filepath in args.input:
+
+        try:
+            # Parse the filename components
+            path = Path(filepath)
+
+            # We replace double underscores with single underscores to deal
+            # with a naming error by TA3 (that will be fixed soon).
+            components = Path(filepath).stem.replace("__", "_").split("_")
+            trial = components[2].split("-")[1]
+            team = str(int(components[3].split("-")[1][2:]))
+            condbtwn = components[4].split("-")[1]
+            condwin = components[5].split("-")[1]
+        except ValueError:
+            warning(f"Could not parse filename: {filepath}")
+            continue
+
+
+        # Process the file
+        with open(filepath) as f:
+            initial_timestamp = None
+            for line in f:
+                # We are only interested in the final transcriptions, not the
+                # intermediate ones.
+                if '"sub_type":"start"' in line:
+                    initial_timestamp = json.loads(line)["msg"]["timestamp"]
+
+                if "asr/final" in line:
+                    message = json.loads(line)
+                    data = message["data"]
+                    timestamp = message["msg"]["timestamp"]
+                    timedelta = relativedelta(parse(timestamp), parse(initial_timestamp))
+                    relative_timestamp = f"{timedelta.minutes}:{timedelta.seconds}"
+                    text = data["text"]
+                    participant_id = data["participant_id"]
+                    line = "\t".join(
+                        (
+                            team,
+                            trial,
+                            condbtwn,
+                            condwin,
+                            timestamp,
+                            relative_timestamp,
+                            participant_id,
+                            text,
+                        )
+                    )
+                    print(line)

--- a/scripts/metadata2tsv
+++ b/scripts/metadata2tsv
@@ -38,6 +38,7 @@ if __name__ == "__main__":
             (
                 "Team",
                 "Trial",
+                "trial_uuid",
                 "CondBtwn",
                 "CondWin",
                 "timestamp",
@@ -50,20 +51,18 @@ if __name__ == "__main__":
 
     for filepath in args.input:
 
+        # Parse the filename components
+        path = Path(filepath)
+        components = Path(filepath).stem.split("_")
         try:
-            # Parse the filename components
-            path = Path(filepath)
-
-            # We replace double underscores with single underscores to deal
-            # with a naming error by TA3 (that will be fixed soon).
-            components = Path(filepath).stem.replace("__", "_").split("_")
-            trial = components[2].split("-")[1]
             team = str(int(components[3].split("-")[1][2:]))
+            trial = components[2].split("-")[1]
             condbtwn = components[4].split("-")[1]
             condwin = components[5].split("-")[1]
-        except ValueError:
+        except:
             warning(f"Could not parse filename: {filepath}")
             continue
+
 
 
         # Process the file
@@ -83,10 +82,12 @@ if __name__ == "__main__":
                     relative_timestamp = f"{timedelta.minutes}:{timedelta.seconds}"
                     text = data["text"]
                     participant_id = data["participant_id"]
+                    trial_uuid = message["msg"]["trial_id"]
                     line = "\t".join(
                         (
                             team,
                             trial,
+                            trial_uuid,
                             condbtwn,
                             condwin,
                             timestamp,

--- a/scripts/sync_asist_data
+++ b/scripts/sync_asist_data
@@ -6,46 +6,68 @@ from pathlib import Path
 
 # Get the path to the data directory, assuming that the repo directory
 # structure is mirrored.
-gcs_dir = "study-1_2020.08"
-data_dir = (
-    Path(os.path.dirname(os.path.realpath(__file__))).parent / "data" / gcs_dir
-)
 
+def sync_asist_data(gcs_dir):
+    data_dir = (
+        Path(os.path.dirname(os.path.realpath(__file__))).parent / "data/studies.aptima.com" / gcs_dir
+    )
 
-os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(data_dir, exist_ok=True)
 
-extensions_to_exclude = (
-    "sav",
-    "pdf",
-    "qsf",
-    "mp4",
-    "m4a",
-    "metadata",
-    "tsv",
-    "png",
-    "PNG",
-    "xlsx",
-    "zip",
-    "csv",
-    "fov",
-    "docx",
-)
+    extensions_to_exclude = {
+        "sav",
+        "pdf",
+        "qsf",
+        "mp4",
+        "m4a",
+        "metadata",
+        "tsv",
+        "png",
+        "PNG",
+        "xlsx",
+        "zip",
+        "csv",
+        "fov",
+        "docx",
+    }
 
-# Construct a regex for gsutil rsync exclusion
-exclusion_regex = (
-    "$|".join((f".*\.{ext}" for ext in extensions_to_exclude)) + "$"
-)
+    if gcs_dir=="study-2_pilot-2_2021.02":
+        extensions_to_exclude.remove("metadata")
 
-run(
-    [
-        "gsutil",
-        "-m",
-        "rsync",
-        "-r",
-        "-x",
-        exclusion_regex,
-        f"gs://studies.aptima.com/{gcs_dir}",
-        data_dir,
-    ],
-    cwd=data_dir,
-)
+    # Construct a regex for gsutil rsync exclusion
+    exclusion_regex = (
+        "$|".join((f".*\.{ext}" for ext in extensions_to_exclude)) + "$"
+    )
+
+    run(
+        [
+            "gsutil",
+            "-m",
+            "rsync",
+            "-r",
+            "-x",
+            exclusion_regex,
+            f"gs://studies.aptima.com/{gcs_dir}",
+            data_dir,
+        ],
+        cwd=data_dir,
+    )
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+
+    parser = ArgumentParser(
+        description="sync_asist_data",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "gcs_dir", type=str, help="GCS directory to sync",
+        choices=("study-1_2020.08", "study-2_pilot-2_2021.02")
+    )
+    args = parser.parse_args()
+
+    # Study 1 GCS dir: study-1_2020.08
+    # Study 2 pilot GCS dir: study-2_pilot-2_2021.02
+
+    sync_asist_data(args.gcs_dir)


### PR DESCRIPTION
This PR updates the `metadata2tsv` and `sync_asist_data` scripts.

`metadata2tsv`: Switched from bash to Python, additional metadata extracted from filenames, relative timestamps now calculated too.

`sync_asist_data`: This script has been updated to get the study 2 pilot data.