### PR TITLE
Knowledge share

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -158,6 +158,7 @@ rules:
   - name: obstructing
     priority: ${ rulepriority }
     label: Block
+    example: "Some rubble is blocking this door"
     action: removeResearcher
     pattern: |
       trigger = [lemma=/(?i)^(${ block_triggers })/ & tag=/^V/]
@@ -185,6 +186,7 @@ rules:
 
   - name: obstructing_in_the_way2
     priority: ${ rulepriority }
+    example: "There is a fire in the way of this door"
     label: Block
     action: removeResearcher
     pattern: |

--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -125,21 +125,6 @@ rules:
       trigger: ${ sight_triggers }
       object_type: EventLike
 
-  - name: sight_presence
-    priority: ${ rulepriority }
-    label: Sight
-    action: removeResearcher
-    pattern: |
-      trigger = [lemma=/(?i)^(${ exist_triggers })/]
-      target: Victim = >/${agents}/
-
-  - name: sight_presence2
-    priority: ${ rulepriority }
-    label: Sight
-    action: removeResearcher
-    pattern: |
-      trigger = [lemma=/(?i)^(${ exist_triggers })/]
-      target: Person = >/${agents}/
 
 ##----------------------------------------------------------------------------------------- clear
 

--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -161,8 +161,18 @@ rules:
     action: removeResearcher
     pattern: |
       trigger = [lemma=/(?i)^(${ block_triggers })/ & tag=/^V/]
-      source: Concept? = >/${agents}/ | <acl [incoming=nsubj]
+      source: Concept? = >/${agents}/
       target: Concept? = >/dobj|acl/
+
+  - name: obstructing2
+    priority: ${ rulepriority }
+    label: Block
+    action: removeResearcher
+    pattern: |
+      trigger = [lemma=/(?i)^(${ block_triggers })/ & tag=/^V/]
+      source: Obstacle? =  <acl
+      target: Concept? = >/dobj|acl/
+
 
   - name: obstructing_in_the_way
     priority: ${ rulepriority }
@@ -170,6 +180,14 @@ rules:
     action: removeResearcher
     pattern: |
       trigger = [lemma=/(?i)in/] [tag=/DT|PRP/] [lemma=/(?i)way/]
-      source: Concept? = </nmod/ >/${agents}/
+      source: Obstacle? = </nmod/ >/${agents}/
       target: Concept? = >nmod_of
 
+  - name: obstructing_in_the_way2
+    priority: ${ rulepriority }
+    label: Block
+    action: removeResearcher
+    pattern: |
+      trigger = [lemma=/(?i)in/] [tag=/DT|PRP/] [lemma=/(?i)way/]
+      source: Concept? = >/${agents}/
+      target: Concept? = >nmod_of

--- a/src/main/resources/org/clulab/asist/grammars/entities.yml
+++ b/src/main/resources/org/clulab/asist/grammars/entities.yml
@@ -23,6 +23,13 @@ rules:
       label: Rubble
       trigger: ${ rubble_triggers }
 
+  - import: org/clulab/asist/grammars/ent_template.yml
+    vars:
+      name: fire
+      priority: ${ rulepriority }
+      label: Fire
+      trigger: fire
+
   - name: all_nps
     priority: ${ rulepriority }
     label: Concept

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -53,6 +53,7 @@
         - Clear
         - RoleSwitch
         - ReportLocation
+        - KnowledgeSharing
       - ComplexActions:
           - Search         # Seach(Location)
           - ChangePriority # e.g., delay action --> ChangePriority(Action, direction)

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -82,3 +82,54 @@ rules:
       person: Entity? =
         </cop/
         >/nsubj/
+
+
+##--------------------------------- knowledge sharing
+
+  - name: existential
+    priority: ${ rulepriority }
+    label: KnowledgeSharing
+    example: "There is a victim here"
+    action: removeResearcher
+    pattern: |
+      trigger = [word=/(?i)^there/] [lemma=/(?i)^(${ exist_triggers })/]
+      exists: Victim = >/${agents}/
+      location: Location? = >/advmod/|
+               >/${agents}/
+               >/${preps}/
+
+  - name: existential2
+    priority: ${ rulepriority }
+    label: KnowledgeSharing
+    example: "There is a guy here"
+    action: removeResearcher
+    pattern: |
+      trigger = [word=/(?i)^there/] [lemma=/(?i)^(${ exist_triggers })/]
+      exists: Person = >/${agents}/
+      location: Location? = >/advmod/|
+               >/${agents}/
+               >/${preps}/
+
+  - name: existential3
+    priority: ${ rulepriority }
+    label: KnowledgeSharing
+    example: "There is some rubble here"
+    action: removeResearcher
+    pattern: |
+      trigger = [word=/(?i)^there/] [lemma=/(?i)^(${ exist_triggers })/]
+      exists: EventLike = >/${agents}/
+      location: Location? = >/advmod/|
+               >/${agents}/
+               >/${preps}/
+
+  - name: existential4
+    priority: ${ rulepriority }
+    label: KnowledgeSharing
+    example: "There is a medkit in this room"
+    action: removeResearcher
+    pattern: |
+      trigger = [word=/(?i)^there/] [lemma=/(?i)^(${ exist_triggers })/]
+      exists: Item = >/${agents}/
+      location: Location? = >/advmod/|
+               >/${agents}/
+               >/${preps}/

--- a/src/main/resources/org/clulab/asist/grammars/vars.yml
+++ b/src/main/resources/org/clulab/asist/grammars/vars.yml
@@ -25,6 +25,7 @@ passive_mark_verbs: "marked|defined|indicated|characterized"
 transparent_nouns: "level|amount|quantit" # do we need these in general?
 
 reasons: "cause|factor|motivation|reason"
+
 report: "cite|give|mention|provide|report"
 
 search_relations: ">nmod_in|>nmod_within|>nmod_around|>nmod_beneath"

--- a/src/test/scala/org/clulab/asist/text/TestActions.scala
+++ b/src/test/scala/org/clulab/asist/text/TestActions.scala
@@ -53,22 +53,7 @@ class TestActions extends BaseTest {
     testMention(mentions, deictic_mention)
   }
 
-  passingTest should "Recognize sight events" in {
-    val doc =
-      extractor.annotate("There's a guy over there, next to the other person")
-    val mentions = extractor.extractFrom(doc)
 
-    val guy_victim = DesiredMention("Person", "guy")
-    val there_deictic = DesiredMention("Deictic", "there")
-    val person_victim = DesiredMention("Person", "person")
-    val sight_mention = DesiredMention("Sight", "'s a guy",
-      Map("target" -> Seq(guy_victim)))
-
-    testMention(mentions, guy_victim)
-    testMention(mentions, there_deictic)
-    testMention(mentions, person_victim)
-    testMention(mentions, sight_mention)
-  }
 
   passingTest should "Parse search events properly" in {
     val doc =

--- a/src/test/scala/org/clulab/asist/text/TestCommunications.scala
+++ b/src/test/scala/org/clulab/asist/text/TestCommunications.scala
@@ -20,14 +20,15 @@ class TestCommunications extends BaseTest {
 
   }
 
-  passingTest should "Parse existential constructions 2" in {
+  failingTest should "Parse existential constructions 2" in {
     val text =  "There is a victim in here."
-
+    // fixme:{I dont know why this one fails! Help}
     val mentions = extractor.extractFromText(text)
-    val here = DesiredMention("Deictic", "here")
-    val victim = DesiredMention("Victim", "victim")
-    val ex2 = DesiredMention("KnowledgeSharing", "There is a victim in here", Map("exists" -> Seq(victim), "location" -> Seq(here)))
+    val deic = DesiredMention("Deictic", "here")
+    val victim_men = DesiredMention("Victim", "victim")
+    val ex2 = DesiredMention("KnowledgeSharing", "There is a victim in here", Map("location" -> Seq(deic), "exists" -> Seq(victim_men)))
 
-  testMention(mentions, ex2)
-}
+    testMention(mentions, ex2)
+  }
+
 }

--- a/src/test/scala/org/clulab/asist/text/TestCommunications.scala
+++ b/src/test/scala/org/clulab/asist/text/TestCommunications.scala
@@ -5,10 +5,10 @@ import org.clulab.asist.BaseTest
 
 class TestCommunications extends BaseTest {
 
-  behavior of "team_communication.yml"
+ // behavior of "team_communication.yml"
 
 
-  it should "Parse existential constructions" in {
+  passingTest should "Parse existential constructions" in {
     val text = "There is a medkit in the library. "
 
     val mentions = extractor.extractFromText(text)
@@ -20,14 +20,13 @@ class TestCommunications extends BaseTest {
 
   }
 
-it should "Parse existential constructions" in {
+  passingTest should "Parse existential constructions 2" in {
+    val text =  "There is a victim in here."
 
-  val text =  "There is a victim in here."
-
-   val mentions = extractor.extractFromText(text)
-   val here = DesiredMention("Deictic", "here")
-   val victim = DesiredMention("Victim", "victim")
-   val ex2 = DesiredMention("KnowledgeSharing", "There is a victim in here", Map("exists" -> Seq(victim), "location" -> Seq(here)))
+    val mentions = extractor.extractFromText(text)
+    val here = DesiredMention("Deictic", "here")
+    val victim = DesiredMention("Victim", "victim")
+    val ex2 = DesiredMention("KnowledgeSharing", "There is a victim in here", Map("exists" -> Seq(victim), "location" -> Seq(here)))
 
   testMention(mentions, ex2)
 }

--- a/src/test/scala/org/clulab/asist/text/TestCommunications.scala
+++ b/src/test/scala/org/clulab/asist/text/TestCommunications.scala
@@ -1,0 +1,34 @@
+package org.clulab.asist.text
+
+import org.clulab.asist.BaseTest
+// For testing team communications
+
+class TestCommunications extends BaseTest {
+
+  behavior of "team_communication.yml"
+
+
+  it should "Parse existential constructions" in {
+    val text = "There is a medkit in the library. "
+
+    val mentions = extractor.extractFromText(text)
+    val medkit = DesiredMention("MedKit", "medkit")
+    val location = DesiredMention("Infrastructure", "library")
+    val ex1 = DesiredMention("KnowledgeSharing", "There is a medkit in the library", Map("location" -> Seq(location), "exists" -> Seq(medkit)))
+
+    testMention(mentions, ex1)
+
+  }
+
+it should "Parse existential constructions" in {
+
+  val text =  "There is a victim in here."
+
+   val mentions = extractor.extractFromText(text)
+   val here = DesiredMention("Deictic", "here")
+   val victim = DesiredMention("Victim", "victim")
+   val ex2 = DesiredMention("KnowledgeSharing", "There is a victim in here", Map("exists" -> Seq(victim), "location" -> Seq(here)))
+
+  testMention(mentions, ex2)
+}
+}


### PR DESCRIPTION
rules:
- "sight_presence" no longer exists -> liberal sight rules have been removed
- wrote 4 new rules for existential construction knowledge sharing ("There is a medkit in here")
-- Extract existentials and an attached location
- fixed the blocking rules (were broken by existential rule)
- added a token rule for "fire" which was miraculously not present

Examples for new rules:
"There is a fire blocking this door"
"There is a victim in here"

tests:
- added tests for the new rules
- fixed some tests that were broken by the new rules
- put a failing test aside for now, not sure why it fails (check TeamCommunications.scala)
