### PR TITLE
optional agent traversal

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -95,7 +95,7 @@ rules:
       trigger = [word=/(?i)^there/] [lemma=/(?i)^(${ exist_triggers })/]
       exists: Victim = >/${agents}/
       location: Location? = >/advmod/|
-               >/${agents}/
+               (>/${agents}/)?
                >/${preps}/
 
   - name: existential2
@@ -107,7 +107,7 @@ rules:
       trigger = [word=/(?i)^there/] [lemma=/(?i)^(${ exist_triggers })/]
       exists: Person = >/${agents}/
       location: Location? = >/advmod/|
-               >/${agents}/
+               (>/${agents}/)?
                >/${preps}/
 
   - name: existential3
@@ -118,8 +118,8 @@ rules:
     pattern: |
       trigger = [word=/(?i)^there/] [lemma=/(?i)^(${ exist_triggers })/]
       exists: EventLike = >/${agents}/
-      location: Location? = >/advmod/|
-               >/${agents}/
+      location: Location? = >/advmod/ |
+               (>/${agents}/)?
                >/${preps}/
 
   - name: existential4
@@ -131,5 +131,5 @@ rules:
       trigger = [word=/(?i)^there/] [lemma=/(?i)^(${ exist_triggers })/]
       exists: Item = >/${agents}/
       location: Location? = >/advmod/|
-               >/${agents}/
+               (>/${agents}/)?
                >/${preps}/

--- a/src/test/scala/org/clulab/asist/text/TestCommunications.scala
+++ b/src/test/scala/org/clulab/asist/text/TestCommunications.scala
@@ -20,7 +20,7 @@ class TestCommunications extends BaseTest {
 
   }
 
-  failingTest should "Parse existential constructions 2" in {
+  passingTest should "Parse existential constructions 2" in {
     val text =  "There is a victim in here."
     // fixme:{I dont know why this one fails! Help}
     val mentions = extractor.extractFromText(text)


### PR DESCRIPTION
@remo-help the issue with the sentence "There is a victim in here." with the existential rules as written is that in the parse the deictic location was attached directly to the BE:
![image](https://user-images.githubusercontent.com/5384073/119812252-cc7f4300-be9c-11eb-9fd8-dc3e0e749be9.png)
So, to address this, I made the `>/${agent}/` traversal optional.
