### PR TITLE
Remo dev

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/ent_template.yml
+++ b/src/main/resources/org/clulab/asist/grammars/ent_template.yml
@@ -2,7 +2,7 @@ vars: org/clulab/asist/grammars/vars.yml
 
 rules:
   - name: ${ name }_detection
-    priority: ${ priority }+
+    priority: ${ priority }
     label: ${ label }
     type: token
     keep: true

--- a/src/main/resources/org/clulab/asist/grammars/entities.yml
+++ b/src/main/resources/org/clulab/asist/grammars/entities.yml
@@ -75,7 +75,7 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)^(${ you_triggers })$/ & tag=/PRP/]
+      [word=/(?i)^(${ you_triggers })$/ & tag=/PRP/]
 
   - name: we_token_capture
     label: Team
@@ -149,4 +149,29 @@ rules:
     keep: false
     pattern: |
       others | other (?! [tag=/^N|CD/]) | (?<= other) [tag=/CD|^N/]
+
+  - name: possesive_pronoun_my
+    priority: ${ rulepriority }
+    label: Self
+    type: token
+    keep: false
+    pattern: |
+      [tag=/PRP/ & word=/my/]
+
+  - name: possesive_pronoun_you
+    priority: ${ rulepriority }
+    label: You
+    type: token
+    keep: false
+    pattern: |
+      [tag=/PRP/ & word=/your/]
+
+  - name: possesive_pronoun_other
+    priority: ${ rulepriority }
+    label: Other
+    type: token
+    keep: false
+    pattern: |
+      [tag=/PRP/ & word=/his|her|their/]
+# the above regex means: match anything but "m" and "o", which will exclude 1st and 2nd person possessive prns
 

--- a/src/main/resources/org/clulab/asist/grammars/master.yml
+++ b/src/main/resources/org/clulab/asist/grammars/master.yml
@@ -8,12 +8,12 @@ rules:
   # Extract the entities
   - import: org/clulab/asist/grammars/entities.yml
     vars:
-      rulepriority: "1"
+      rulepriority: "1+"
 
   # Extract the items
   - import: org/clulab/asist/grammars/items.yml
     vars:
-      rulepriority: "1"
+      rulepriority: "1+"
 
   # Extract the sentiments
   - import: org/clulab/asist/grammars/sentiments.yml

--- a/src/main/resources/org/clulab/asist/grammars/questions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/questions.yml
@@ -41,7 +41,7 @@ rules:
     pattern: |
       trigger = @QuestionParticle (?= [lemma=be])
       topic: Concept = >nsubj
-      location: Location? = >/${positional_preps}/
+      location: Location? = >nsubj >/${positional_preps}/
 
 
 #leave this here so I can remember how to do these complex dependencies

--- a/src/main/resources/org/clulab/asist/grammars/questions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/questions.yml
@@ -24,14 +24,24 @@ rules:
       location: Location? = >/${positional_preps}/
 
   - name: information_gathering_question_that
-    example: "What is that?  What is that over there"
+    example: "What is that? What is that in the library?"
     priority: ${ rulepriority }
     label: Question
     action: removeResearcher
     pattern: |
-      trigger = @QuestionParticle
+      trigger = @QuestionParticle (?= [lemma=be])
       topic: Concept = <nsubj [lemma=/be|do/] >dep
       location: Location? = <nsubj [lemma=/be|do/] >dep >/${positional_preps}/
+
+  - name: information_gathering_question_that2
+    example: "What's that over there?"
+    priority: ${ rulepriority }
+    label: Question
+    action: removeResearcher
+    pattern: |
+      trigger = @QuestionParticle (?= [lemma=be])
+      topic: Concept = >nsubj
+      location: Location? = >/${positional_preps}/
 
   - name: information_gathering_question_clarification
     example: "What is the plan?"

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -52,6 +52,7 @@
           - Disagreement
         - Clear
         - RoleSwitch
+        - RoleDeclare
         - ReportLocation
         - KnowledgeSharing
       - ComplexActions:

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -61,7 +61,17 @@ rules:
     pattern: |
       trigger = [lemma=/(?i)^(${ role_switch_triggers })/ & tag=/^V/]
       agent: Entity? = >/(${agents})/
-      target: Role? = >/nmod_to|xcomp/
+      target: Role = >/nmod_to|xcomp/
+
+  - name: role_declare
+    priority: ${ rulepriority }
+    label: RoleDeclare
+    example: "I am an engineer"
+    action: removeResearcher
+    pattern: |
+      trigger = [lemma=/(?i)^be/]
+      target: Role = <cop
+      agent: Entity = <cop >/(${agents})/
 
   - name: role_switch_change_to
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/asist/grammars/time.yml
+++ b/src/main/resources/org/clulab/asist/grammars/time.yml
@@ -15,3 +15,11 @@ rules:
     type: token
     pattern: |
       (?<value> [word=/(?i)last|first/ | tag=/^DT/] [word=/(?i)few|several|couple/]) of? (?<trigger> [lemma=/(?i)second|minute|hour|day|year/])
+
+  - name: time_mention
+    label: Time
+    priority: 1
+    type: token
+    keep: false
+    pattern: |
+      [lemma=/time/]

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -21,6 +21,7 @@ fire_triggers: "fire|blaze|flame"
 infrastructure_triggers: "room|door|building|stairs|window|floor|ceiling|house|roof|bathroom|hall|entrance|library|balcony"
 
 room_singleword_surface_regex: "armory|attic|ballroom|basement|bathroom|bedroom|boardroom|cabin|cellar|classroom|courtroom|cubby|den|entry|garage|gym|hall|hallway|kitchen|kitchenette|library|lobby|loft|lounge|lunchroom|mailroom|office|restroom|schoolroom|stockroom|storeroom|studio|study|suite|washroom|workroom"
+
 room_twoword_first_word_regex: "back|boiler|conference|control|dining|engine|front|ladies'|laundry|living|locker|men's|utility|waiting|weight|women's"
 
 switch_triggers: "switch|toggle|lever|door"


### PR DESCRIPTION
**Items:**
- owner argument now works as intended
- added a non-extracted entity for possessive pronouns, labels: Self, You, Other (shared with other rules)
- changed extraction priority for entities.yml and items.yml to '1+'

**Communication & Commitment:**
- added a "declare role" rule, example: "I am a medic", "Delta is an engineer"
- This also expands functionality of commintment, we can nox extract utterances like: "Can you be an engineer?"

**Questions**:
- fixed a bug where locations where not extracted as intended in questions such as "What is that over there?"
- fixed some failing question Test

