### PR TITLE
Updating processors version to 8.4.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ resolvers += "Artifactory" at "http://artifactory.cs.arizona.edu:8081/artifactor
 
 libraryDependencies += "io.spray" %%  "spray-json" % "1.3.5"
 libraryDependencies ++= {
-  val procVer = "8.4.0"
+  val procVer = "8.4.2"
 
   Seq(
     "org.clulab"    %% "processors-main"          % procVer,


### PR DESCRIPTION
This PR updates the `processors` version to 8.4.2 in order to use the changes in https://github.com/clulab/processors/pull/519.