### PR TITLE
Case class for DialogAgent args

### DIFF
--- a/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
@@ -30,10 +30,23 @@ import scala.io.Source
  *  @param nMatches maximum number of taxonomy_matches to return (up to 5)
  */
 
-class DialogAgent (val nMatches: Int = 0) extends LazyLogging {
+
+// A place to keep a growing number of settings for the Dialog Agent
+case class DialogAgentArgs(
+  val nMatches: Int = 0,  // Number of taxonomy matches to include with extractions
+  val withClassifier: Boolean = false // query the Dialog Act Classification server
+)
+
+
+class DialogAgent (
+  val args: DialogAgentArgs = new DialogAgentArgs
+) extends LazyLogging {
 
   private val config: Config = ConfigFactory.load()
   private val pretty: Boolean = config.getBoolean("DialogAgent.pretty_json")
+
+  val nMatches = args.nMatches
+  val withClassifier = args.withClassifier
 
   val dialogAgentMessageType = "event"
   val dialogAgentSource = "tomcat_textAnalyzer"

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentFile.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentFile.scala
@@ -24,7 +24,7 @@ import scala.util.control.NonFatal
 class DialogAgentFile(
   val inputFilename: String = "",
   val outputFilename: String = "",
-  override val nMatches: Int = 0
+  override val args: DialogAgentArgs = new DialogAgentArgs
 ) extends DialogAgent with LazyLogging {
 
   /** process one input file

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -27,7 +27,7 @@ import scala.util.control.Exception._
 class DialogAgentMqtt(
   val host: String = "",
   val port: String = "",
-  override val nMatches: Int = 0
+  override val args: DialogAgentArgs = new DialogAgentArgs
 ) extends DialogAgent 
   with MessageBusClientListener { 
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentReprocessor.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentReprocessor.scala
@@ -53,9 +53,9 @@ import scala.util.control.NonFatal
  *
  */
 class DialogAgentReprocessor (
-  val inputDirName: String,
-  val outputDirName: String,
-  override val nMatches: Int = 0
+  val inputDirName: String = "",
+  val outputDirName: String = "",
+  override val args: DialogAgentArgs = new DialogAgentArgs
 ) extends DialogAgent with LazyLogging {
 
   val startTime = Clock.systemUTC.millis

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
@@ -14,7 +14,7 @@ import java.util.Scanner
  */
 
 class DialogAgentStdin (
-  override val nMatches: Int = 0
+  override val args: DialogAgentArgs = new DialogAgentArgs
 ) extends DialogAgent { 
 
   println("\nDialog Agent stdin extractor running.")


### PR DESCRIPTION
Reduce command line argument proliferation in the source code by using a case class instead of discrete values.