### PR TITLE
adding insights from study2 data

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -65,7 +65,7 @@ rules:
       agent: Entity? = >/${agents}/
 ## This one is not working right now, working on it -Remo
 
-  - import: org/clulab/asist/grammars/lvo_template.yml
+  - import: org/clulab/asist/grammars/lvo_template_no_passive.yml
     vars:
       name: search
       template_priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/asist/grammars/lvo_template.yml
+++ b/src/main/resources/org/clulab/asist/grammars/lvo_template.yml
@@ -8,6 +8,9 @@ rules:
       trigger = [lemma=/(?i)^(${ trigger })/]
       agent: Entity? = >/${agents}/
       target: ${ object_type } = >dobj
+      location: Location? = >/${objects}/ >/advmod/|
+               >/${objects}/ >/${preps}/|
+               >/${preps}/
 
   - name: passive-${name}
     priority: ${ template_priority }

--- a/src/main/resources/org/clulab/asist/grammars/lvo_template_no_passive.yml
+++ b/src/main/resources/org/clulab/asist/grammars/lvo_template_no_passive.yml
@@ -1,0 +1,13 @@
+vars: org/clulab/asist/grammars/vars.yml
+
+rules:
+  - name: lemma_verb_dobj-${name}
+    priority: ${ template_priority }
+    label: ${ label }
+    pattern: |
+      trigger = [lemma=/(?i)^(${ trigger })/]
+      agent: Entity? = >/${agents}/
+      target: ${ object_type } = >dobj
+      location: Location? = >/${objects}/ >/advmod/|
+               >/${objects}/ >/${preps}/|
+               >/${preps}/

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -61,6 +61,8 @@
         - RoleSwitch
         - RoleDeclare
         - ReportLocation
+        - ReportItemStatus:
+            - ToolBroken
         - KnowledgeSharing:
           - RoomStatus:
             - RoomClear

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -65,7 +65,7 @@ rules:
     label: RoleDeclare
     example: "I am an engineer"
     pattern: |
-      trigger = [lemma=/(?i)^be/]
+      trigger = [lemma=/(?i)^be|Im/ & tag=VBP]
       target: Role = <cop
       agent: Entity = <cop >/(${agents})/
 
@@ -160,7 +160,21 @@ rules:
       exists: Victim = >/${objects}/
       location: Location? = >/${objects}/ >/advmod/|
                >/${objects}/ >/${preps}/|
-               >/${preps}/
+               >/${preps}/|
+               >/advmod/
+
+
+  - name: found_victim_have
+    priority: ${ rulepriority }
+    label: KnowledgeSharing
+    example: "I have a victim here"
+    pattern: |
+      trigger =[lemma=/(?i)have/]
+      exists: Victim = >/${objects}/
+      location: Location? = >/${objects}/ >/advmod/|
+               >/${objects}/ >/${preps}/|
+               >/${preps}/|
+               >/advmod/
 
 
 

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -65,7 +65,7 @@ rules:
     label: RoleDeclare
     example: "I am an engineer"
     pattern: |
-      trigger = [lemma=/(?i)^be|Im/ & tag=VBP]
+      trigger = [lemma=/(?i)^be/ & tag=VBP]
       target: Role = <cop
       agent: Entity = <cop >/(${agents})/
 

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -156,7 +156,7 @@ rules:
     label: KnowledgeSharing
     example: "I found a victim in the library"
     pattern: |
-      trigger =[lemma=/(?i)^find|found/]
+      trigger =[lemma=/(?i)^find|found|locate|spot/]
       exists: Victim = >/${objects}/
       location: Location? = >/${objects}/ >/advmod/|
                >/${objects}/ >/${preps}/|

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -87,6 +87,13 @@ rules:
         </cop/
         >/nsubj/
 
+  - name: report_broken_item
+    priority: ${ rulepriority }
+    label: ToolBroken
+    pattern: |
+      trigger = [lemma=/(?i)broken|break/]
+      tool: Tool = >/nsubj|dobj/
+
 
 ##--------------------------------- knowledge sharing
 
@@ -143,6 +150,19 @@ rules:
       obstacle: Obstacle? = >/${agents}/
                             >/${positional_preps}/
       map: Map? = >/${positional_preps}/
+
+  - name: found_victim
+    priority: ${ rulepriority }
+    label: KnowledgeSharing
+    example: "I found a victim in the library"
+    pattern: |
+      trigger =[lemma=/(?i)^find|found/]
+      exists: Victim = >/${objects}/
+      location: Location? = >/${objects}/ >/advmod/|
+               >/${objects}/ >/${preps}/|
+               >/${preps}/
+
+
 
   - name: room_clear
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -79,7 +79,7 @@ room_twoword_second_word_regex: "(room|cafe|office|terrace|area|storage|coffee|c
 
 rubble_triggers: "rubble|blockage|pile|stuff|obstacle|barricade|rebel"
 
-search_spec_triggers: "search|service|searcher"
+search_spec_triggers: "search|service|searcher|scout"
 
 search_triggers: "hunt|look|search|check"
 

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -81,9 +81,9 @@ rubble_triggers: "rubble|blockage|pile|stuff|obstacle|barricade|rebel"
 
 search_spec_triggers: "search|service|searcher"
 
-search_triggers: "find|hunt|look|search|check"
+search_triggers: "hunt|look|search|check"
 
-self_triggers: "i|me"
+self_triggers: "i|me|my"
 
 sight_triggers: "see|observe|glimpse"
 

--- a/src/test/scala/org/clulab/asist/rules/TestCommunications.scala
+++ b/src/test/scala/org/clulab/asist/rules/TestCommunications.scala
@@ -43,4 +43,27 @@ class TestCommunications extends BaseTest {
     testMention(mentions, cleared)
   }
 
+  passingTest should "Parse the found victim rule" in {
+    val text = "I found a victim in the library. "
+
+    val mentions = extractor.extractFrom(text)
+    val victim = DesiredMention("Victim", "victim")
+    val location = DesiredMention("Infrastructure", "library")
+    val ex1 = DesiredMention("KnowledgeSharing", "found a victim in the library", Map("location" -> Seq(location), "exists" -> Seq(victim)), Set(PAST_TENSE))
+
+    testMention(mentions, ex1)
+
+  }
+
+  passingTest should "Parse role switch events" in {
+    val text = "I'm switching to engineer. "
+
+    val mentions = extractor.extractFrom(text)
+    val engineer = DesiredMention("Engineer", "engineer")
+    val self = DesiredMention("Self","I")
+    val ex1 = DesiredMention("RoleSwitch", "switching to engineer", Map("target" -> Seq(engineer)),Set(AGENT_SELF))
+
+    testMention(mentions, ex1)
+
+  }
 }


### PR DESCRIPTION
changelog:
- new lvo_template now has an entry for a location
- new file: lvo_template_no_passive.yml (self-explanatory)

- ReportItemStatus:
- - added new taxonomy class, ReportItemStatus with subdivision: ToolBroken
- - added a teamcommunication rule: report_broken_tool

- KnowledgeSharing:
- - added new rule in KnowledgeSharing: found_victim; this will trigger "I found a victim here"
- - added new rule for "I have a victim here"

- removed "find" from the search_triggers

- added "scout" as a trigger for search_specialist

- tests:
- - added tests for "found victim" and "switch role"