### PR TITLE
Fixed a case class namespace collision

### DIFF
--- a/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
@@ -18,7 +18,7 @@ import scala.io.Source
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
  *
- *  Updated:  2021 July
+ *  Updated:  2021 August
  *
  *  Create extractions from text for the ToMCAT project.
  *
@@ -142,7 +142,7 @@ class DialogAgent (
       asr_msg_id,
       text,
       dialog_act_label = null, // ...
-      DialogAgentMessageDataSource(
+      DialogAgentMessageUtteranceSource(
         source_type,
         source_name
       ),
@@ -164,13 +164,13 @@ class DialogAgent (
   /** Return an array of all extractions found in the input text
    *  @param text Speech to analyze
    */
-  def getExtractions(text: String): Seq[DialogAgentMessageDataExtraction] = 
+  def getExtractions(text: String): Seq[DialogAgentMessageUtteranceExtraction] = 
     extractMentions(text).map(getExtraction)
 
   /** Create a DialogAgent extraction from Extractor data 
    *  @param mention Contains text to analyze
    */
-  def getExtraction(mention: Mention): DialogAgentMessageDataExtraction = {
+  def getExtraction(mention: Mention): DialogAgentMessageUtteranceExtraction = {
     val originalArgs = mention.arguments.toArray
     val extractionArguments = for {
       (role, ms) <- originalArgs
@@ -178,7 +178,7 @@ class DialogAgent (
     } yield (role, converted)
     val extractionAttachments = mention.attachments.map(writeJson(_))
     val taxonomy_matches = taxonomyMatches(mention.label)
-    DialogAgentMessageDataExtraction(
+    DialogAgentMessageUtteranceExtraction(
       mention.label,
       mention.words.mkString(" "),
       extractionArguments.toMap,

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentReprocessor.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentReprocessor.scala
@@ -28,7 +28,7 @@ import scala.util.{Failure, Success}
 /**
  * Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
  *
- * Updated:  2021 July
+ * Updated:  2021 August
  *
  * Reprocess metadata JSON files by reading each line as a JValue and then 
  * processing according to the topic field.  Lines with topics not addressed
@@ -432,9 +432,9 @@ class DialogAgentReprocessor (
       participant_id = data.participant_id,
       asr_msg_id = data.asr_msg_id,
       text = data.text,
-      source = new DialogAgentMessageDataSource(
-        source_type = data.source.source_type,
-        source_name = data.source.source_name
+      utterance_source = new DialogAgentMessageUtteranceSource(
+        source_type = data.utterance_source.source_type,
+        source_name = data.utterance_source.source_name
       ),
       extractions = getExtractions(data.text)
     )
@@ -442,7 +442,9 @@ class DialogAgentReprocessor (
     case NonFatal(t) => {
       logger.error(s"reprocessDialogAgentMessageData could not parse ${json}")
       logger.error(t.toString)
-      new DialogAgentMessageData(source = new DialogAgentMessageDataSource)
+      new DialogAgentMessageData(
+        utterance_source = new DialogAgentMessageUtteranceSource
+      )
     }
   }
 

--- a/src/main/scala/org/clulab/asist/messages/DialogActClassifierMessage.scala
+++ b/src/main/scala/org/clulab/asist/messages/DialogActClassifierMessage.scala
@@ -3,7 +3,7 @@ package org.clulab.asist.messages
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
  *
- *  Updated:  2021 July
+ *  Updated:  2021 August
  *
  *  Classifier messages
  *
@@ -14,7 +14,7 @@ package org.clulab.asist.messages
 case class DialogActClassifierMessage(
   participant_id: String = "",
   text: String = "",
-  extractions:Seq[DialogAgentMessageDataExtraction] = Seq.empty
+  extractions:Seq[DialogAgentMessageUtteranceExtraction] = Seq.empty
 )
 
 // returned from DAC server

--- a/src/main/scala/org/clulab/asist/messages/DialogAgentMessage.scala
+++ b/src/main/scala/org/clulab/asist/messages/DialogAgentMessage.scala
@@ -5,7 +5,7 @@ import org.json4s.jackson.Serialization.read
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
  *
- *  Updated:  2021 June
+ *  Updated:  2021 August
  *
  *  Dialog Agent Message
  *
@@ -14,16 +14,16 @@ import org.json4s.jackson.Serialization.read
  */
 
 /** Part of the DialogAgentMessageData class */
-case class DialogAgentMessageDataSource(
+case class DialogAgentMessageUtteranceSource(
   source_type: String = null,
   source_name: String = null
 )
 
 /** Part of the DialogAgentMessageData class */
-case class DialogAgentMessageDataExtraction(
+case class DialogAgentMessageUtteranceExtraction(
   label: String = null,
   span: String = null,
-  arguments: Map[String, Seq[DialogAgentMessageDataExtraction]] = Map.empty,
+  arguments: Map[String, Seq[DialogAgentMessageUtteranceExtraction]] = Map.empty,
   attachments: Set[String] = Set.empty, // Json strings
   start_offset: Int = 0,
   end_offset: Int = 0,
@@ -36,8 +36,8 @@ case class DialogAgentMessageData(
   asr_msg_id: String = null,
   text: String = null,
   dialog_act_label: String  = null,  // Dialog Act Classifier query result.
-  source: DialogAgentMessageDataSource,
-  extractions:Seq[DialogAgentMessageDataExtraction] = Seq.empty
+  utterance_source: DialogAgentMessageUtteranceSource,
+  extractions:Seq[DialogAgentMessageUtteranceExtraction] = Seq.empty
 )
 
 /** Contains the full analysis data of one chat message */


### PR DESCRIPTION
This PR fixes a namespace collision where the DialogAgentMessage.data and VersionInfo.data structures both had a field named "source" that was causing Elastic to throw errors because the datatypes were different.