### PR TITLE
anchor on boundaries, use lemma for text

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,3 +20,6 @@ DialogAgent {
     pretty_json = false
     inputDir = ""
 }
+
+apps.eval.maxMentions = 50
+apps.eval.maxFiles = 1

--- a/src/main/resources/org/clulab/asist/grammars/marker_meanings.yml
+++ b/src/main/resources/org/clulab/asist/grammars/marker_meanings.yml
@@ -6,7 +6,7 @@ rules:
     label: MarkerMeaning
     keep: true
     pattern: |
-      trigger = [lemma=/one|two|three|1|2|3/]
+      trigger = [lemma=/\b(one|two|three|1|2|3)\b/]
       meaning: Victim = <nummod? <nsubj >dobj?
 
   - name: marker_meaning_token
@@ -15,7 +15,7 @@ rules:
     type: token
     keep: true
     pattern: |
-      @meaning:Victim /is|has|as|are|for/ for? (?<trigger> [lemma=/one|two|three|1|2|3/])
+      @meaning:Victim /is|has|as|are|for/ for? (?<trigger> [lemma=/\b(one|two|three|1|2|3)\b/])
 
   - name: marker_meaning_token_flipped
     priority: ${ rulepriority }
@@ -23,7 +23,7 @@ rules:
     type: token
     keep: true
     pattern: |
-      (?<trigger> [lemma=/one|two|three|1|2|3/]) [lemma=/be|say|show/] for? @meaning: Victim
+      (?<trigger> [lemma=/\b(one|two|three|1|2|3)\b/]) [lemma=/be|say|show/] for? @meaning: Victim
 
   - name: marker_meaning_two_misparsed
     priority: ${ rulepriority }
@@ -31,7 +31,7 @@ rules:
     type: token
     keep: true
     pattern: |
-      (?<trigger> [lemma=/to|too/]) [lemma=/be|say|show|indicate/] []{,2} @meaning: Victim
+      (?<trigger> [lemma=/\b(to|too)\b/]) [lemma=/\b(be|say|show|indicate)\b/] []{,2} @meaning: Victim
 
 
   # handle to instead of two

--- a/src/main/scala/org/clulab/asist/extraction/TomcatActions.scala
+++ b/src/main/scala/org/clulab/asist/extraction/TomcatActions.scala
@@ -221,7 +221,9 @@ class TomcatActions() extends Actions with LazyLogging {
     mention.label match {
       case MARKER_MEANING =>
         mention match {
-          case event: EventMention => Some(MarkerId(event.trigger.text))
+          case event: EventMention =>
+            val lemmaText = event.trigger.lemmas.get.mkString(" ")
+            Some(MarkerId(lemmaText))
           case _ =>
             logger.warn(s"MarkerMeaning mention found that wasn't an EventMention, no attachment created. (${mention.text})")
             None


### PR DESCRIPTION
fixes some over matching on marker meaning rules -- e.g., we were matching "drone" with /one/