### PR TITLE
Eval fixes

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -100,6 +100,15 @@ rules:
     label: MoveTo
     pattern: |
       trigger = [lemma=/(?i)^(${ moveto_triggers })$/ & tag=/^V/] (?! ([]? away) | (to [tag=/^VB/]))
+      target: Location =  >/nmod_(through|to|toward|by|over|in_front_of|next_to)/ | >/${objects}/
+      agent: Entity? = >/${agents}/
+
+  - name: move_victim
+    priority: ${ rulepriority }
+    label: MoveVictim
+    pattern: |
+      trigger = [lemma=/(?i)^(${ move_victim_triggers })$/ & tag=/^V/]
+      victim: Victim = >/dobj/
       target: Location? =  >/nmod_(through|to|toward|by|over|in_front_of|next_to)/ | >/${objects}/
       agent: Entity? = >/${agents}/
 

--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -102,7 +102,7 @@ rules:
       trigger = [lemma=/(?i)^(${ moveto_triggers })$/ & tag=/^V/] (?! ([]? away) | (to [tag=/^VB/]))
       target: Location =  >/nmod_(through|to|toward|by|over|in_front_of|next_to)/ | >/${objects}/
       agent: Entity? = >/${agents}/
-      direction: Direction = >/advmod/
+      direction: Direction? = >/advmod/
 
 
   - name: move_nmod_direction

--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -103,6 +103,13 @@ rules:
       target: Location =  >/nmod_(through|to|toward|by|over|in_front_of|next_to)/ | >/${objects}/
       agent: Entity? = >/${agents}/
 
+  - name: move_keep_false
+    priority: ${ rulepriority }
+    label: Move
+    keep: false
+    pattern: |
+      trigger = [lemma=/(?i)^(${ moveto_triggers })$/ & tag=/^V/] (?! ([]? away) | (to [tag=/^VB/]))
+
   - name: move_victim
     priority: ${ rulepriority }
     label: MoveVictim

--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -101,8 +101,9 @@ rules:
     pattern: |
       trigger = [lemma=/(?i)^(${ moveto_triggers })$/ & tag=/^V/] (?! ([]? away) | (to [tag=/^VB/]))
       target: Location =  >/nmod_(through|to|toward|by|over|in_front_of|next_to)/ | >/${objects}/
+      direction: Direction? = >/advmod/
       agent: Entity? = >/${agents}/
-
+##### \\fixme: why is the direction argument not working??
   - name: move_keep_false
     priority: ${ rulepriority }
     label: Move

--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -101,9 +101,18 @@ rules:
     pattern: |
       trigger = [lemma=/(?i)^(${ moveto_triggers })$/ & tag=/^V/] (?! ([]? away) | (to [tag=/^VB/]))
       target: Location =  >/nmod_(through|to|toward|by|over|in_front_of|next_to)/ | >/${objects}/
-      direction: Direction? = >/advmod/
       agent: Entity? = >/${agents}/
-##### \\fixme: why is the direction argument not working??
+      direction: Direction = >/advmod/
+
+
+  - name: move_nmod_direction
+    priority: ${ rulepriority }
+    label: Move
+    pattern: |
+      trigger = [lemma=/(?i)^(${ moveto_triggers })$/ & tag=/^V/] (?! ([]? away) | (to [tag=/^VB/]))
+      direction: Direction = >/advmod/
+      agent: Entity? = >/${agents}/
+
   - name: move_keep_false
     priority: ${ rulepriority }
     label: Move

--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -109,6 +109,7 @@ rules:
     keep: false
     pattern: |
       trigger = [lemma=/(?i)^(${ moveto_triggers })$/ & tag=/^V/] (?! ([]? away) | (to [tag=/^VB/]))
+      agent: Entity? = >/${agents}/
 
   - name: move_victim
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -102,7 +102,6 @@ rules:
       trigger = [lemma=/(?i)^(${ moveto_triggers })$/ & tag=/^V/] (?! ([]? away) | (to [tag=/^VB/]))
       target: Location =  >/nmod_(through|to|toward|by|over|in_front_of|next_to)/ | >/${objects}/
       agent: Entity? = >/${agents}/
-      direction: Direction? = >/advmod/
 
 
   - name: move_nmod_direction

--- a/src/main/resources/org/clulab/asist/grammars/base_concepts.yml
+++ b/src/main/resources/org/clulab/asist/grammars/base_concepts.yml
@@ -18,7 +18,24 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)${ medic_triggers }/] [word=/(?i)(${ specialist_triggers })/]?
+      [word=/(?i)\b${ medic_triggers }\b/] [word=/(?i)(${ specialist_triggers })/]?
+
+  - name: medic_strict_token
+    priority: ${ rulepriority }
+    label: Medic
+    type: token
+    keep: true
+    pattern: |
+      /\bmedic\b/ [word=/(?i)(${ specialist_triggers })/]?
+
+
+  - name: medical_specialist
+    priority: ${ rulepriority }
+    label: Medic
+    type: token
+    keep: true
+    pattern: |
+      [word=/(?i)medical/] [word=/(?i)(${ specialist_triggers })/]
 
   - name: engineer
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/asist/grammars/locations.yml
+++ b/src/main/resources/org/clulab/asist/grammars/locations.yml
@@ -115,20 +115,45 @@ rules:
       trigger = [lemma=/(?i)^(${ zone_triggers })$/]
       num: Number = >/(conj_(and|or)|nummod)/
 
-  - name: directions
+  - name: up_directions
     priority: ${ first_priority }
-    label: Direction
+    label: Up
+    type: token
+    keep: false
+    pattern: |
+      [lemma=/\b(up)(ward)?\b/ & !outgoing=xcomp & !tag=VBD] (?! [word=/(?i)now|away|here|there|over/])
+
+  - name: down_directions
+    priority: ${ first_priority }
+    label: Down
+    type: token
+    keep: false
+    pattern: |
+      [lemma=/\b(down)(ward)?\b/ & !outgoing=xcomp & !tag=VBD] (?! [word=/(?i)now|away|here|there|over/])
+
+  - name: right_direction
+    priority: ${ first_priority }
+    label: Right
     type: token
     keep: true
     pattern: |
-      [lemma=/\b(up|down|left|right)(ward|most|ish)?\b/ & !outgoing=xcomp & !tag=VBD] (?! [word=/(?i)now|away|here|there|over/])
+      (?<= [word=/(?i)the/]) [word=/\b(right)\b/ & !outgoing=xcomp & !tag=VBD] |  [word=/\b(right)\b/ & !outgoing=xcomp & !tag=VBD] (?= [word=/(?i)of/])
+
+  - name: left_direction
+    priority: ${ first_priority }
+    label: Left
+    type: token
+    keep: true
+    pattern: |
+      (?<= [word=/(?i)the/]) [word=/\b(left)\b/ & !outgoing=xcomp & !tag=VBD] |  [word=/\b(left)\b/ & !outgoing=xcomp & !tag=VBD] (?= [word=/(?i)of/])
+
 
   - name: relative_location
     priority: ${ second_priority }
     label: Location
     pattern: |
       trigger = @Direction [lemma=/half|part|side|section/]?
-      target: Concept? = >/nmod_of/
+      target: Concept = >/nmod_of/
 
   - name: location_area
     priority: ${ second_priority }

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -5,6 +5,7 @@ rules:
   - name: instruction_command
     priority: ${ rulepriority }
     label: Instruction
+    keep: true
     pattern: |
       trigger = (?<! I []*) [tag=VB & mention=Action] (?! []* I)
       agent: Entity? = >/^nsubj/ [!mention=Self]

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -88,7 +88,7 @@ rules:
     priority: ${ rulepriority }
     label: RoleSwitch
     pattern: |
-      trigger = [lemma=/change/]
+      trigger = [lemma=/change/ | word=/searching/]
       agent: Entity? = >/(${agents})/
       target: Role = >/nmod_to/
 

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -53,7 +53,7 @@ hammer_triggers: "hammer|hummer|mallet|sledgehammer|sledge hammer|sledge-hammer"
 
 infrastructure_triggers: "room|door|building|stairs|window|floor|ceiling|house|roof|bathroom|hall|entrance|library|balcony"
 
-medic_triggers: "medic|paramedic|nurse|doctor|medical"
+medic_triggers: "paramedic|nurse|doctor"
 
 medkit_triggers: "medkit|medical kit|med kit|medicalkit|medical kid|med kid"
 

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -61,6 +61,8 @@ movefrom_triggers: "depart|exit|leave"
 
 moveto_triggers: "go|move|run|walk|come|scoot|climb|jump"
 
+move_victim_triggers: "move|transfer|transport"
+
 north_triggers: "north"
 
 open_triggers: "open"

--- a/src/test/scala/org/clulab/asist/rules/TestActions.scala
+++ b/src/test/scala/org/clulab/asist/rules/TestActions.scala
@@ -68,10 +68,10 @@ class TestActions extends BaseTest {
   }
 
   passingTest should "Parse move events properly" in {
-    val doc = extractor.annotate("Let's run to the office.")
+    val doc = extractor.annotate("run to the office.")
     val mentions = extractor.extractFrom(doc)
     val location= DesiredMention("Infrastructure", "office")
-    val move_mention = DesiredMention("MoveTo", "run", Map("target" -> Seq(location)))
+    val move_mention = DesiredMention("MoveTo", "run to the office", Map("target" -> Seq(location)))
 
     testMention(mentions, move_mention)
   }

--- a/src/test/scala/org/clulab/asist/rules/TestActions.scala
+++ b/src/test/scala/org/clulab/asist/rules/TestActions.scala
@@ -68,10 +68,10 @@ class TestActions extends BaseTest {
   }
 
   passingTest should "Parse move events properly" in {
-    val doc = extractor.annotate("Let's run over.")
+    val doc = extractor.annotate("Let's run to the office.")
     val mentions = extractor.extractFrom(doc)
-
-    val move_mention = DesiredMention("MoveTo", "run")
+    val location= DesiredMention("Infrastructure", "office")
+    val move_mention = DesiredMention("MoveTo", "run", Map("target" -> Seq(location)))
 
     testMention(mentions, move_mention)
   }

--- a/src/test/scala/org/clulab/asist/rules/TestQuestions.scala
+++ b/src/test/scala/org/clulab/asist/rules/TestQuestions.scala
@@ -40,13 +40,13 @@ class TestQuestions extends BaseTest {
     testMention(mentions, desired6)
   }
 
-  it should "find location questions with `location_moving_question` rule" in {
+  failingTest should "find location questions with `location_moving_question` rule" in {
     val text = "Where did they go?"
     val mentions = extractor.extractFrom(text)
     val move = DesiredMention("MoveTo", "go", Map.empty, Set(PAST_TENSE, AGENT_ENTITY))
     val desired1 = DesiredMention("LocationQuestion", "Where did they go", Map("topic" -> Seq(move)), Set(PAST_TENSE))
     testMention(mentions, desired1)
-  }
+  } //fixme: we need to make an exception to the obligatory move argument for this, perhaps a movement rule that is not being kept
 
   it should "handle information gathering questions" in {
     // information_gathering_question_that

--- a/src/test/scala/org/clulab/asist/rules/TestQuestions.scala
+++ b/src/test/scala/org/clulab/asist/rules/TestQuestions.scala
@@ -40,10 +40,10 @@ class TestQuestions extends BaseTest {
     testMention(mentions, desired6)
   }
 
-  failingTest should "find location questions with `location_moving_question` rule" in {
+  it should "find location questions with `location_moving_question` rule" in {
     val text = "Where did they go?"
     val mentions = extractor.extractFrom(text)
-    val move = DesiredMention("MoveTo", "go", Map.empty, Set(PAST_TENSE, AGENT_ENTITY))
+    val move = DesiredMention("Move", "go", Map.empty, Set(PAST_TENSE, AGENT_ENTITY))
     val desired1 = DesiredMention("LocationQuestion", "Where did they go", Map("topic" -> Seq(move)), Set(PAST_TENSE))
     testMention(mentions, desired1)
   } //fixme: we need to make an exception to the obligatory move argument for this, perhaps a movement rule that is not being kept


### PR DESCRIPTION
this PR fixes a host of some of the more egregious issues we discovered in the evaluation:

- made 1 argument obligatory for all movement rules, avoiding vacuous extractions. Kept one argument-less rule with keep:false
- implemented a MoveVictim rule with a victim as an argument

- severely restricted the "directions" rule by splitting it into multiple rules with lookahead and lookbehind restrictions. This should fix most of the overmatching of things like "Oh, right"
- fixed overmatching of the "medic" rule on the "medical" token

- some minor fixes
- fixed all broken tests