### PR TITLE
VersionInfo source version now tracks buildInfo.BuildInfo

### DIFF
--- a/src/main/scala/org/clulab/asist/messages/VersionInfo.scala
+++ b/src/main/scala/org/clulab/asist/messages/VersionInfo.scala
@@ -1,7 +1,7 @@
 package org.clulab.asist.messages
 
 import org.clulab.asist.agents.DialogAgent
-
+import buildinfo.BuildInfo
 
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
@@ -18,22 +18,22 @@ import org.clulab.asist.agents.DialogAgent
 
 /** Configuration settings */
 case class VersionInfoDataConfig(
-  name: String = "Not Set",
-  value: String = "Not Set"
+  name: String = null,
+  value: String = null,
 )
 
 /** channel on the Message Bus */
 case class VersionInfoDataMessageChannel(
-  topic: String = "Not Set",
-  message_type: String = "Not Set",
-  sub_type: String = "Not Set"
+  topic: String = null,
+  message_type: String = null,
+  sub_type: String = null,
 )
 
 /** Part of the Info class */
 case class VersionInfoData(
-  agent_name: String = "Not Set",
-  owner: String = "Not Set",
-  version: String = "Not Set",
+  agent_name: String = null,
+  owner: String = null,
+  version: String = null,
   source: Seq[String] = List(),
   dependencies: Seq[String] = List(),
   config: Seq[VersionInfoDataConfig] = List(),
@@ -86,6 +86,9 @@ object VersionInfoMetadata {
 // testbed configuration
 object VersionInfo 
 {
+  val dataSource = 
+    s"https://gitlab.asist.aptima.com:5050/asist/testbed/uaz_dialog_agent:${BuildInfo.version}"
+
   // create a VersionInfo by copying some fields from the input CommonMsg
   def apply(
     agent: DialogAgent,
@@ -113,9 +116,7 @@ object VersionInfo
     agent_name = "tomcat_textAnalyzer",
     owner = "University of Arizona",
     version = agent.dialogAgentVersion,
-    source = List(
-      "https://gitlab.asist.aptima.com:5050/asist/testbed/uaz_dialog_agent:2.0.0"
-    ),
+    source = List(dataSource),
     dependencies = List(),
     config = List(),
     publishes = List(


### PR DESCRIPTION
tomcat-text software version number reported in the VersionInfo.data.source field now tracks version number set by sbt when reading the version.sbt build file.