### PR TITLE
MQTT Agent experiment_id value is now set correctly

### DIFF
--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -162,7 +162,7 @@ class DialogAgentMqtt(
     val tm = read[TrialMessage](input.line)
     if(tm.msg.sub_type == "start") {
       val currentTimestamp = Clock.systemUTC.instant.toString
-      val versionInfo = VersionInfo(this, currentTimestamp)
+      val versionInfo = VersionInfo(this, tm, currentTimestamp)
       val outputJson = write(versionInfo)
       if(withClassifications) {
         val rs1 = RSM.setInputTopic(new RunState, input.topic)


### PR DESCRIPTION
Fixed a bug in the MQTT Agent where the experiment_id value was not being set.