### PR TITLE
Updates to metadata2tsv and documentation generation scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ data/fall2020_extractions.txt: scripts/run_fall2020_analysis
 extraction_schemas.json: scripts/build_docs
 	$<
 
-extraction_schemas_compact.md: scripts/process_extraction_schemas_json extraction_schemas.json
+extraction_schemas_compact.md: scripts/process_extraction_schemas_json extraction_schemas.json version.sbt
 	$^ > $@
 
 extraction_schemas.pdf: extraction_schemas_compact.md

--- a/scripts/metadata2tsv
+++ b/scripts/metadata2tsv
@@ -73,23 +73,24 @@ if __name__ == "__main__":
                     timestamp = message["msg"]["timestamp"]
                     timedelta = relativedelta(parse(timestamp), parse(initial_timestamp))
                     relative_timestamp = f"{timedelta.minutes}:{timedelta.seconds}"
-                    text = data["text"]
-                    if "asr/final" in line:
-                        participant_id = data["participant_id"]
-                    elif "userspeech" in line:
-                        participant_id = data["playername"]
-                    trial_uuid = message["msg"]["trial_id"]
-                    line = "\t".join(
-                        (
-                            team,
-                            trial,
-                            trial_uuid,
-                            condbtwn,
-                            condwin,
-                            timestamp,
-                            relative_timestamp,
-                            participant_id,
-                            text,
+                    if "text" in data and "is_final" in data:
+                        text = data["text"]
+                        if "asr/final" in line:
+                            participant_id = data["participant_id"]
+                        elif "userspeech" in line:
+                            participant_id = data["playername"]
+                        trial_uuid = message["msg"]["trial_id"]
+                        line = "\t".join(
+                            (
+                                team,
+                                trial,
+                                trial_uuid,
+                                condbtwn,
+                                condwin,
+                                timestamp,
+                                relative_timestamp,
+                                participant_id,
+                                text,
+                            )
                         )
-                    )
-                    print(line)
+                        print(line)

--- a/scripts/metadata2tsv
+++ b/scripts/metadata2tsv
@@ -64,19 +64,21 @@ if __name__ == "__main__":
             for i, line in enumerate(f):
                 # We are only interested in the final transcriptions, not the
                 # intermediate ones.
-                if '"sub_type":"start"' in line:
+                try:
+                    message = json.loads(line)
+                except json.JSONDecodeError:
+                    raise RuntimeError(
+                            f"Unable to parse line {i+1} in {filepath} as JSON.\n"
+                            + line
+                            )
+
+                if message["msg"]["sub_type"] == "start":
                     initial_timestamp = json.loads(line)["msg"]["timestamp"]
 
-                if "asr/final" in line or "userspeech" in line:
-                    try:
-                        message = json.loads(line)
-                    except json.JSONDecodeError:
-                        raise RuntimeError(
-                                f"Unable to parse line {i+1} in {filepath} as JSON.\n"
-                                + line
-                                )
+                if "topic" in message and message["topic"] == "agent/asr/final":
                     data = message["data"]
                     timestamp = message["msg"]["timestamp"]
+
                     try:
                         timedelta = relativedelta(parse(timestamp), parse(initial_timestamp))
                     except TypeError:
@@ -87,12 +89,10 @@ if __name__ == "__main__":
                                 +f"Timestamp: {timestamp}"
                                 )
                     relative_timestamp = f"{timedelta.minutes}:{timedelta.seconds}"
+
                     if "text" in data and "is_final" in data:
                         text = data["text"]
-                        if "asr/final" in line:
-                            participant_id = data["participant_id"]
-                        elif "userspeech" in line:
-                            participant_id = data["playername"]
+                        participant_id = data["participant_id"]
                         trial_uuid = message["msg"]["trial_id"]
                         line = "\t".join(
                             (

--- a/scripts/metadata2tsv
+++ b/scripts/metadata2tsv
@@ -61,17 +61,31 @@ if __name__ == "__main__":
         # Process the file
         with open(filepath) as f:
             initial_timestamp = None
-            for line in f:
+            for i, line in enumerate(f):
                 # We are only interested in the final transcriptions, not the
                 # intermediate ones.
                 if '"sub_type":"start"' in line:
                     initial_timestamp = json.loads(line)["msg"]["timestamp"]
 
                 if "asr/final" in line or "userspeech" in line:
-                    message = json.loads(line)
+                    try:
+                        message = json.loads(line)
+                    except json.JSONDecodeError:
+                        raise RuntimeError(
+                                f"Unable to parse line {i+1} in {filepath} as JSON.\n"
+                                + line
+                                )
                     data = message["data"]
                     timestamp = message["msg"]["timestamp"]
-                    timedelta = relativedelta(parse(timestamp), parse(initial_timestamp))
+                    try:
+                        timedelta = relativedelta(parse(timestamp), parse(initial_timestamp))
+                    except TypeError:
+                        raise RuntimeError(
+                                f"Unable to parse timestamps in line {i+1} in {filepath}\n"
+                                +line+"\n"
+                                +f"Initial timestamp: {initial_timestamp}\n"
+                                +f"Timestamp: {timestamp}"
+                                )
                     relative_timestamp = f"{timedelta.minutes}:{timedelta.seconds}"
                     if "text" in data and "is_final" in data:
                         text = data["text"]

--- a/scripts/process_extraction_schemas_json
+++ b/scripts/process_extraction_schemas_json
@@ -7,12 +7,14 @@ import json
 from datetime import datetime
 
 input_file = sys.argv[1]
+version_file = sys.argv[2]
 
 # Version of the dialog agent for which this documentation is being
 # generated.
 
 #TODO - have this be read from a text file instead of hard-coded.
-AGENT_VERSION = "2.2.1"
+with open(version_file) as f:
+    agent_version = f.read().split()[-1].replace('"', "")
 
 with open(input_file) as f:
     data = json.load(f)
@@ -86,7 +88,7 @@ Extractions
 
 ```
 """.format(
-            agent_version=AGENT_VERSION, date=datetime.utcnow()
+            agent_version=agent_version, date=datetime.utcnow()
         )
     )
 


### PR DESCRIPTION
- The `metadata2tsv` script has been robustified somewhat, and support for ASR messages on the `userspeech` has been removed. The script has been tested on the most recent version of the ASIST Study 2 data.
- The `process_extraction_schemas_json` script now reads the version number from the top-level `version.sbt` file instead of having it be hard-coded in the script.