### PR TITLE
Eval fixes 2

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/base_concepts.yml
+++ b/src/main/resources/org/clulab/asist/grammars/base_concepts.yml
@@ -45,6 +45,15 @@ rules:
     pattern: |
       [lemma=/(?i)${ engineer_triggers }/] [word=/(?i)(${ specialist_triggers })/]?
 
+  - name: engineer_alt
+    priority: ${ rulepriority }
+    label: Engineer
+    type: token
+    keep: true
+    pattern: |
+      ([word=/\bhammer\b/] [lemma=/(?i)^(${ person_triggers })/])
+
+
   # ------------- CALL SIGNS --------------------------
   - name: alpha
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/asist/grammars/ent_template.yml
+++ b/src/main/resources/org/clulab/asist/grammars/ent_template.yml
@@ -7,5 +7,5 @@ rules:
     type: token
     keep: true
     pattern: |
-      ([tag=/^NN/ & incoming=compound] [lemma=/(?i)^(${ trigger })/ & outgoing=compound]) |
-      [lemma=/(?i)^(${ trigger })/]+
+      ([tag=/^NN/ & incoming=compound] [lemma=/(?i)^(${ trigger })\b/ & outgoing=compound]) |
+      [lemma=/(?i)^(${ trigger })\b/]+

--- a/src/main/resources/org/clulab/asist/grammars/entities.yml
+++ b/src/main/resources/org/clulab/asist/grammars/entities.yml
@@ -1,12 +1,15 @@
 vars: org/clulab/asist/grammars/vars.yml
 
 rules:
-  - import: org/clulab/asist/grammars/ent_template.yml
-    vars:
-      name: person
-      priority: ${ rulepriority }
-      label: Person
-      trigger: ${ person_triggers }
+
+  - name: person_detection
+    priority: ${ rulepriority }
+    label: Person
+    type: token
+    keep: false
+    pattern: |
+      ([tag=/^NN/ & incoming=compound] [lemma=/(?i)^(${ person_triggers })\b/ & outgoing=compound]) |
+              [lemma=/(?i)^(${ person_triggers })\b/]+
 
   - name: victim
     priority: ${ rulepriority }
@@ -54,7 +57,7 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/no/] [lemma=/one|victim/]
+      [lemma=/\bno\b/] [lemma=/\bone\b|victim/]
 
 
 

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -79,7 +79,7 @@ room_twoword_first_word_regex: "(cubicle|sundollar|Herbalife|limping lamb|lamb|s
 
 room_twoword_second_word_regex: "(room|cafe|office|terrace|area|storage|coffee|chophouse)"
 
-rubble_triggers: "rubble|blockage|pile|stuff|obstacle|barricade|rebel"
+rubble_triggers: "rubble|blockage|pile|stuff|obstacle|barricade|rebel|gravel"
 
 search_spec_triggers: "search|service|searcher|scout"
 

--- a/src/test/scala/org/clulab/asist/rules/EntityTest.scala
+++ b/src/test/scala/org/clulab/asist/rules/EntityTest.scala
@@ -4,7 +4,7 @@ import org.clulab.asist.BaseTest
 
 class EntityTest extends BaseTest {
 
-  passingTest should "Recognize person and victim" in {
+  failingTest should "Recognize person and victim" in {
     val doc = extractor.annotate("Look at this dude. My guy where are the victims?")
     val mentions = extractor.extractFrom(doc)
 


### PR DESCRIPTION
big changes: the person_detection rule now only extracts a person if it used as an argument in another rule. This means that strings like "dude" or "guy" will no longer be extracted as entities, unless they are used in another extraction, such as: "saving this dude"

small changes: fixed some tests and added functionality to cover more mistranscriptions