### PR TITLE
Webapp and configurability updates

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -29,6 +29,18 @@ DialogAgent {
 
     // Directory to write the reprocessed .metadata files to
     outputDir = "reprocessed_output"
+
+    // 'msg.source' property in published messages
+    msgSource = "tomcat_textAnalyzer"
+
+    // 'msg.sub_type' property in published messages
+    msgSubType = "Event:dialogue_event"
+
+    // Topic to which extraction messages should be published
+    outputTopic = "agent/dialog"
+
+    // URL for the Texas A&M University Dialogue Act Classifier service
+    dacServerURL = "http://localhost:8000"
 }
 
 // Maximum number of mentions to output

--- a/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
@@ -1,6 +1,7 @@
 package org.clulab.asist.agents
 
 import ai.lum.common.ConfigFactory
+import org.clulab.processors.Document
 import buildinfo.BuildInfo
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
@@ -44,15 +45,16 @@ case class DialogAgentArgs(
 )
 
 class DialogAgent (
-  val args: DialogAgentArgs = new DialogAgentArgs
+  val args: DialogAgentArgs = new DialogAgentArgs,
+  val engine: TomcatRuleEngine = new TomcatRuleEngine
 ) extends LazyLogging {
 
   private val config: Config = ConfigFactory.load()
   private val pretty: Boolean = config.getBoolean("DialogAgent.pretty_json")
 
   val dialogAgentMessageType = "event"
-  val dialogAgentSource = "tomcat_textAnalyzer"
-  val dialogAgentSubType = "Event:dialogue_event"
+  val dialogAgentSource = config.getString("DialogAgent.msgSource") 
+  val dialogAgentSubType = config.getString("DialogAgent.msgSubType")
   val dialogAgentVersion = BuildInfo.version
 
   // metadata topics
@@ -60,7 +62,7 @@ class DialogAgent (
   val topicSubUazAsr = "agent/asr/final"
   val topicSubAptimaAsr = "status/asistdataingester/userspeech"
   val topicSubTrial = "trial"
-  val topicPubDialogAgent = "agent/dialog"
+  val topicPubDialogAgent = config.getString("DialogAgent.outputTopic")
   val topicPubVersionInfo = "agent/tomcat_textAnalyzer/versioninfo"
 
   val subscriptions = List(
@@ -92,10 +94,10 @@ class DialogAgent (
     Source.fromResource("taxonomy_map.json").mkString
   ).convertTo[immutable.Map[String, Array[immutable.Map[String, String]]]]
 
-  // Create the extractor and run it to get lazy init out of the way 
+  // Create the engine and run it to get lazy init out of the way 
   logger.info("Initializing Extractor (this may take a few seconds) ...")
-  val extractor = new TomcatRuleEngine()
-  extractor.extractFrom("green victim")
+  //val engine = new TomcatRuleEngine()
+  engine.extractFrom("green victim")
   logger.info("Extractor initialized.")
 
   /** Create a CommonHeader data structure 
@@ -123,8 +125,14 @@ class DialogAgent (
    * @return sequence of Odin Mentions
    */
   def extractMentions(text: String): Seq[Mention] = {
-    extractor
+    engine
       .extractFrom(Option(text).getOrElse(""), keepText = true)
+      .sortBy(m => (m.sentence, m.label))
+  }
+
+  def extractMentions(doc: Document): Seq[Mention] = {
+    engine
+      .extractFrom(doc)
       .sortBy(m => (m.sentence, m.label))
   }
 
@@ -153,8 +161,36 @@ class DialogAgent (
       ),
       getExtractions(text)
     )
-  
-  /** map the mention label to the taxonomy map, the mappings are static
+
+   /** Create the data component of the DialogAgentMessage structure
+   *  @param participant_id human subject who created the text
+   *  @param asr_msg_id from the Automated Speech Recognition system
+   *  @param source_type Source of message data, either message_bus or a file
+   *  @param source_name topic or filename
+   *  @param text The text to be analyzed by the pipeline 
+   *  @param extractions extractions obtained from the text
+   */
+  def dialogAgentMessageData(
+    participant_id: String,
+    asr_msg_id: String, 
+    source_type: String,
+    source_name: String,
+    text: String,
+    extractions: Seq[DialogAgentMessageUtteranceExtraction]
+  ): DialogAgentMessageData = 
+    DialogAgentMessageData(
+      participant_id,
+      asr_msg_id,
+      text,
+      dialog_act_label = null, // ...
+      DialogAgentMessageUtteranceSource(
+        source_type,
+        source_name
+      ),
+      extractions
+    )
+ 
+  /** Map the mention label to the taxonomy map, the mappings are static
    * and computed ahead of time and stored sorted // FIXME: is this true?.
    * @param mentionLabel For taxonomy mapping
    */
@@ -167,10 +203,13 @@ class DialogAgent (
     }
 
   /** Return an array of all extractions found in the input text
-   *  @param text Speech to analyze
+   *  @param text Text to analyze
    */
   def getExtractions(text: String): Seq[DialogAgentMessageUtteranceExtraction] = 
     extractMentions(text).map(getExtraction)
+
+  def getExtractions(mentions: Seq[Mention]): Seq[DialogAgentMessageUtteranceExtraction] = 
+    mentions.map(getExtraction)
 
   /** Create a DialogAgent extraction from Extractor data 
    *  @param mention Contains text to analyze

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -1,5 +1,7 @@
 package org.clulab.asist.agents
 
+import ai.lum.common.ConfigFactory
+import com.typesafe.config.Config
 import akka.actor.ActorSystem
 import akka.http.scaladsl._
 import akka.http.scaladsl.model._
@@ -50,9 +52,10 @@ class DialogAgentMqtt(
     with LazyLogging
     with MessageBusClientListener { 
 
+  private val config: Config = ConfigFactory.load()
   logger.info(s"DialogAgentMqtt version ${dialogAgentVersion}")
 
-  val serverLocation = "http://localhost:8000"
+  val serverLocation = config.getString("DialogAgent.dacServerURL") 
 
   // actors
   implicit val ec = ExecutionContext.global

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
@@ -22,12 +22,12 @@ class DialogAgentStdin (
 
   print("\n> ")
 
-  // console input
+  // Console input
   val input = new Scanner(System.in)
 
   // Read keyboard input until user hits [CTRL-D]
   while (input.hasNextLine){
-    val extractions = extractor.extractFrom(input.nextLine, keepText = true)
+    val extractions = engine.extractFrom(input.nextLine, keepText = true)
     extractions.map(getExtraction).map(f => println(writeJson(f)))
     print("\n> ")
   }

--- a/webapp/app/views/index.scala.html
+++ b/webapp/app/views/index.scala.html
@@ -24,13 +24,15 @@
             <input type="submit">
         </form>
 
-        <div id="eidosMentions"></div>
+        <div id="mentions"></div>
 
         <br>
 
         <div id="syntax"></div>
 
-        <div id="groundedAdj" class="add-info"></div>
+        <div id="extractions" class="add-info"></div>
+
+        <pre id="extractionJsons"></pre>
 
         <table id="parse"></table>
     </body>

--- a/webapp/public/javascripts/main.js
+++ b/webapp/public/javascripts/main.js
@@ -47,37 +47,25 @@ var collData = {
     {
             "type"   : "NounPhrase",
             "labels" : ["NounPhrase", "NP"],
-            // Blue is a nice colour for a person?
-            //"bgColor": "thistle",
             "bgColor": baseNounPhraseColor,
-            // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
         {
             "type"   : "NounPhrase-Inc",
             "labels" : ["NounPhrase", "NP"],
-            // Blue is a nice colour for a person?
-            //"bgColor": "thistle",
             "bgColor": increaseNounPhraseColor,
-            // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
         {
             "type"   : "NounPhrase-Dec",
             "labels" : ["NounPhrase", "NP"],
-            // Blue is a nice colour for a person?
-            //"bgColor": "thistle",
             "bgColor": decreaseNounPhraseColor,
-            // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
         {
             "type"   : "NounPhrase-Quant",
             "labels" : ["NounPhrase", "NP"],
-            // Blue is a nice colour for a person?
-            //"bgColor": "thistle",
             "bgColor": quantifiedNounPhraseColor,
-            // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
      ],
@@ -310,7 +298,7 @@ head.ready(function() {
         $.extend({}, docData),
         webFontURLs
     );
-    var eidosMentionsLiveDispatcher = Util.embed('eidosMentions',
+    var mentionsLiveDispatcher = Util.embed('mentions',
         $.extend({'collection': null}, collData),
         $.extend({}, docData),
         webFontURLs
@@ -350,8 +338,10 @@ head.ready(function() {
         .done(function (data) {
             console.log(data);
             syntaxLiveDispatcher.post('requestRenderData', [$.extend({}, data.syntax)]);
-            eidosMentionsLiveDispatcher.post('requestRenderData', [$.extend({}, data.eidosMentions)]);
-            document.getElementById("groundedAdj").innerHTML = data.mentionDetails;
+            mentionsLiveDispatcher.post('requestRenderData', [$.extend({}, data.mentions)]);
+            document.getElementById("extractions").innerHTML = data.mentionDetails;
+            document.getElementById("extractionJsons").innerHTML = 
+                "<h2>Message</h2>"+JSON.stringify(JSON.parse(data.extractionJsons), undefined, 2);
             document.getElementById("parse").innerHTML = data.parse;
 
             // Hide spinner


### PR DESCRIPTION
- Refactored code so that `msg.source`, `msg.sub_type`, the output publishing topic for the extractions, and the DAC server URL can now be configured using `application.conf`
- Updated the webapp to show the `data` portion of the DialogAgent output messages as prettified JSON.
- Renamed a couple of variables to have consistent semantics
- Added an argument to the DialogAgent constructor so that we can use an external `TomcatRuleEngine` instance.