### PR TITLE
Quick fix

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -279,3 +279,7 @@ rules:
       trigger = [lemma=in] [tag=/DT|PRP/] [lemma=/(?i)^way\b/]
       source: Concept? = >/${agents}/
       target: Concept? = >nmod_of
+
+#\\ todo: #"put down marker block"
+#\\ todo: #review the instruction rule... "And going to go renew my hammer and then come back."
+#\\ todo: #mark rooms: "Oh, I should mark the rooms i'll mark them with a one if I get everything from." "All right, this is green, I will be putting a three if there's nobody in the room, so nobody accidentally goes in there."

--- a/src/main/resources/org/clulab/asist/grammars/base_concepts.yml
+++ b/src/main/resources/org/clulab/asist/grammars/base_concepts.yml
@@ -43,7 +43,7 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)${ engineer_triggers }/] [word=/(?i)(${ specialist_triggers })/]?
+      [lemma=/(?i)${ engineer_triggers }/ & tag=/^NN/] [word=/(?i)(${ specialist_triggers })/]?
 
   - name: engineer_alt
     priority: ${ rulepriority }
@@ -60,4 +60,4 @@ rules:
     priority: ${ rulepriority }
     type: token
     pattern: |
-      [lemma=/(?i)plan|strategy/]
+      [lemma=/(?i)\bplan\b|strategy/]

--- a/src/main/resources/org/clulab/asist/grammars/entities.yml
+++ b/src/main/resources/org/clulab/asist/grammars/entities.yml
@@ -106,7 +106,7 @@ rules:
     type: token
     keep: false
     pattern: |
-      [lemma=/(?i)^${ deixis_triggers }/] (?! [lemma=be]) # prevent "There is..."
+      [word=/(?i)^${ deixis_triggers }/] (?! [lemma=be]) # prevent "There is..."
 
   # minecraft door switch, e.g.
   - name: switch

--- a/src/main/resources/org/clulab/asist/grammars/entities.yml
+++ b/src/main/resources/org/clulab/asist/grammars/entities.yml
@@ -27,6 +27,14 @@ rules:
     pattern: |
       [lemma=/(?i)critical/] [lemma=/(?i)(${ victim_triggers })/]
 
+  - name: critical_solitary
+    priority: ${ rulepriority }
+    label: CriticalVictim
+    type: token
+    keep: true
+    pattern: |
+      (?<=a|an|some) [word=/(?i)critical/]
+
   - name: critical_injured_victim
     priority: ${ rulepriority }
     label: CriticalVictim

--- a/src/main/resources/org/clulab/asist/grammars/entities.yml
+++ b/src/main/resources/org/clulab/asist/grammars/entities.yml
@@ -172,7 +172,7 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)^(red)/]
+      [lemma=/(?i)^(red)/] | /RAD/
 
   - name: blue
     label: Blue

--- a/src/main/resources/org/clulab/asist/grammars/locations.yml
+++ b/src/main/resources/org/clulab/asist/grammars/locations.yml
@@ -16,7 +16,7 @@ rules:
       [lemma=/(?i)^(${ infrastructure_triggers })/]+
 
   - name: room_detection
-    priority: ${ first_priority }
+    priority: ${ second_priority }
     label: Room
     type: token
     keep: true

--- a/src/main/resources/org/clulab/asist/grammars/master.yml
+++ b/src/main/resources/org/clulab/asist/grammars/master.yml
@@ -38,9 +38,9 @@ rules:
   # Extract the locations
   - import: org/clulab/asist/grammars/locations.yml
     vars:
-      first_priority: "4-5"
-      second_priority: "6"
-      third_priority: "7"
+      first_priority: "4+"
+      second_priority: "5"
+      third_priority: "6"
 
   # Extract the base_concepts
   - import: org/clulab/asist/grammars/base_concepts.yml
@@ -80,12 +80,12 @@ rules:
   # Extract questions
   - import: org/clulab/asist/grammars/questions.yml
     vars:
-      rulepriority: "5-11"
+      rulepriority: "6+"
 
   # Extract team_comms
   - import: org/clulab/asist/grammars/team_communication.yml
     vars:
-      rulepriority: "5-11"
+      rulepriority: "6+"
 
   # Extract temporal extractions
   - import: org/clulab/asist/grammars/temporal_extractions.yml

--- a/src/main/resources/org/clulab/asist/grammars/master.yml
+++ b/src/main/resources/org/clulab/asist/grammars/master.yml
@@ -80,12 +80,12 @@ rules:
   # Extract questions
   - import: org/clulab/asist/grammars/questions.yml
     vars:
-      rulepriority: "5+"
+      rulepriority: "5-11"
 
   # Extract team_comms
   - import: org/clulab/asist/grammars/team_communication.yml
     vars:
-      rulepriority: "5+"
+      rulepriority: "5-11"
 
   # Extract temporal extractions
   - import: org/clulab/asist/grammars/temporal_extractions.yml

--- a/src/main/resources/org/clulab/asist/grammars/master.yml
+++ b/src/main/resources/org/clulab/asist/grammars/master.yml
@@ -90,4 +90,6 @@ rules:
   # Extract temporal extractions
   - import: org/clulab/asist/grammars/temporal_extractions.yml
     vars:
-      rulepriority: "9+"
+      rulepriority: "10+"
+      earlypriority: "9+"
+

--- a/src/main/resources/org/clulab/asist/grammars/questions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/questions.yml
@@ -34,7 +34,7 @@ rules:
     pattern: |
       trigger = @QuestionParticle (?= [lemma=be])
       topic: Concept = <nsubj [lemma=/be|do/] >dep
-      location: Location? = <nsubj [lemma=/be|do/] >dep >/${positional_preps}/
+      location: Location? = <nsubj [lemma=/be|do/] >dep >/${positional_preps_+advmod}/
 
   - name: information_gathering_question_that2
     example: "What's that over there?"
@@ -43,7 +43,7 @@ rules:
     pattern: |
       trigger = @QuestionParticle (?= [lemma=be])
       topic: Concept = >nsubj
-      location: Location? = >/${positional_preps}/
+      location: Location? = >/${positional_preps_+advmod}/
 
   - name: information_gathering_question_clarification
     example: "What is the plan?"
@@ -62,7 +62,7 @@ rules:
     pattern: |
       trigger = (?<! [mention=QuestionParticle]) [lemma=/(?i)^do|can|will|should|have|could/]
       topic: Action = <aux
-      location: Location? = <aux >/${positional_preps}/
+      location: Location? = <aux >/${positional_preps_+advmod}/
       agent: Entity? = <aux >/(${agents})/
 
 #leave this here so I can remember how to do these complex dependencies

--- a/src/main/resources/org/clulab/asist/grammars/questions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/questions.yml
@@ -9,8 +9,14 @@ rules:
       trigger = [lemma=/(?i)^(${ where_triggers })/]
       topic: Entity =
         <advmod [lemma=be]
+        >/nsubj|dobj|nmod/ |
+        <advmod [lemma=be]
         >/nsubj|dobj|nmod/
+        >dep |
+        <advmod [lemma=be]
+        <cop
       location: Location? = >/${positional_preps}/
+# the second entity version is there so we can capture cases such as "where are you at green?" and extract green as the entity
 
   - name: location_moving_question
     example: "Where did you go?"

--- a/src/main/resources/org/clulab/asist/grammars/questions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/questions.yml
@@ -43,7 +43,7 @@ rules:
     pattern: |
       trigger = @QuestionParticle (?= [lemma=be])
       topic: Concept = >nsubj
-      location: Location? = >/${positional_preps_+advmod}/
+      location: Location? = >/${positional_preps_liberal+advmod}/
 
   - name: information_gathering_question_clarification
     example: "What is the plan?"

--- a/src/main/resources/org/clulab/asist/grammars/sentiments.yml
+++ b/src/main/resources/org/clulab/asist/grammars/sentiments.yml
@@ -18,13 +18,21 @@ rules:
     pattern: |
       [lemma=/(?i)^sound/] [word=/(?i)good/]
 
+  - name: agreement3
+    label: Agreement
+    priority: ${ rulepriority }
+    type: token
+    keep: true
+    pattern: |
+      [word=/(?i)^all$/] [word=/(?i)^right$/]
+
   - name: agree_token_match
     label: Agreement
     priority: ${ rulepriority }
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)^(${ agree_triggers })$/]
+      [lemma=/(?i)^(${ agree_triggers })$/] (?!no)
 
   - name: disagree_token_match
     label: Disagreement

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -190,6 +190,7 @@ rules:
       exists: Victim = >/${objects}/
       location: Location? = >/${objects}/ >/advmod/|
                >/${objects}/ >/${preps}/|
+               >/${objects}/ >/${positional_preps_liberal}/|
                >/${preps}/|
                >/advmod/
 

--- a/src/main/resources/org/clulab/asist/grammars/temporal_extractions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/temporal_extractions.yml
@@ -1,41 +1,10 @@
 vars: org/clulab/asist/grammars/vars.yml
 
 rules:
-  - name: precedence1
-    priority: ${ rulepriority }
-    label: Precedence
-    pattern: |
-      trigger = [lemma=/(?i)^(${ then_precedence_triggers })/]
-      first: EventLike? =
-        # get to the second action, which is linked to the first
-        <advmod
-        # traverse the link -- depending on the phrasing, can be any of these
-        </ccomp|conj_and|dep/
-        # optionally go to an embedded clause
-        >/xcomp/?
-        # land on a verb
-        [tag=/^V/]
-      second: EventLike? = <advmod
 
-  - name: precedence2
-    priority: ${ rulepriority }
-    label: Precedence
-    pattern: |
-      trigger = [lemma=/(?i)^(${ before_precedence_triggers })/]
-      first: EventLike? =
-        # get to the second action, which is linked to the first
-        </mark/
-        # traverse the link between the actions
-        </advcl_before/
-        # optionally go to an embedded clause
-        >/xcomp/?
-        # land on a verb
-        [tag=/^V/]
-      second: EventLike? = </mark/
-    ##still need 1st action for before
 
   - name: precedence2_after
-    priority: ${ rulepriority }
+    priority: ${ earlypriority }
     label: Precedence
     pattern: |
       trigger = [lemma=/(?i)^(${ after_precedence_triggers })/]
@@ -52,7 +21,7 @@ rules:
 
 
   - name: precedence3_token_after
-    priority: ${ rulepriority }
+    priority: ${ earlypriority }
     label: Precedence
     type: token
     pattern: |
@@ -61,6 +30,40 @@ rules:
       @first:EventLike
       []? [tag=/PRP/]? []?
       @second:EventLike
+
+
+  - name: precedence1
+    priority: ${ rulepriority }
+    label: Precedence
+    pattern: |
+      trigger = [lemma=/(?i)^(${ then_precedence_triggers })/] (?! ([]? after))
+      first: EventLike? =
+        # get to the second action, which is linked to the first
+        <advmod
+        # traverse the link -- depending on the phrasing, can be any of these
+        </ccomp|conj_and|dep/
+        # optionally go to an embedded clause
+        >/xcomp/?
+        # land on a verb
+        [tag=/^V/]
+      second: EventLike? = <advmod
+
+  - name: precedence2
+    priority: ${ rulepriority }
+    label: Precedence
+    pattern: |
+      trigger = [lemma=/(?i)^(${ then_precedence_triggers })/] (?! ([]? after))
+      first: EventLike? =
+        # get to the second action, which is linked to the first
+        </mark/
+        # traverse the link between the actions
+        </advcl_before/
+        # optionally go to an embedded clause
+        >/xcomp/?
+        # land on a verb
+        [tag=/^V/]
+      second: EventLike? = </mark/
+    ##still need 1st action for before
 
   - name: precedence3_token_before
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -12,7 +12,7 @@ change_priority_triggers: "target|prioritize|focus"
 
 charlie_triggers: "charlie"
 
-clear_triggers: "clear|remove|clear|break"
+clear_triggers: "clear|remove|clear|break|excavate"
 
 close_triggers: "close|shut"
 
@@ -33,7 +33,7 @@ encouragement_triggers1: "good|well|perfect|amazing|excellent|great|awesome"
 
 encouragement_triggers2: "job|done|work"
 
-engineer_triggers: "hazmat|engineer" # "heavy equipment specialist|equipment specialist|heavy specialist" <- these need separate rules
+engineer_triggers: "hazmat|engineer|heavy" # "heavy equipment specialist|equipment specialist|heavy specialist" <- these need separate rules
 
 exist_triggers: "be"
 
@@ -43,7 +43,7 @@ fire_triggers: "fire|blaze|flame"
 
 foe_triggers: "zombie|mob|enemy|skeleton"
 
-hammer_triggers: "hammer|hummer|mallet|sledgehammer|sledge hammer|sledge-hammer"
+hammer_triggers: "hammer|hummer|mallet|sledgehammer|sledge hammer|sledge-hammer|shovel"
 
 infrastructure_triggers: "door|building|stairs|window|floor|ceiling|house|roof|bathroom|hall|entrance|library|balcony|hallway"
 
@@ -73,7 +73,7 @@ room_twoword_first_word_regex: "(cubicle|sundollar|Herbalife|limping lamb|lamb|s
 
 room_twoword_second_word_regex: "(room|cafe|office|terrace|area|storage|coffee|chophouse)"
 
-rubble_triggers: "rubble|blockage|pile|stuff|obstacle|barricade|rebel|gravel"
+rubble_triggers: "rubble|blockage|pile|stuff|obstacle|barricade|rebel|gravel|pile"
 
 search_spec_triggers: "search|service|searcher|scout"
 
@@ -105,7 +105,7 @@ triage_triggers: "save|triage|heal|help|get|rescue"
 
 triage_triggers_strict: "save|triage|heal|rescue"
 
-victim_triggers: "victim|patient"
+victim_triggers: "victim|patient|person"
 
 west_triggers: "west"
 

--- a/src/main/resources/org/clulab/asist/grammars/vars.yml
+++ b/src/main/resources/org/clulab/asist/grammars/vars.yml
@@ -32,7 +32,9 @@ search_relations: ">nmod_in|>nmod_within|>nmod_around|>nmod_beneath"
 
 positional_preps: "nmod_(behind|beneath|in|in_front_of|on|over|under|dep)"
 
-positional_preps_liberal: "nmod_(behind|beneath|in|in_front_of|on|over|under|[a-z]+|dep)"
+positional_preps_liberal+advmod: "nmod_(behind|beneath|in|in_front_of|on|over|under|[a-z]+)|dep|advmod"
+
+positional_preps_liberal: "nmod_(behind|beneath|in|in_front_of|on|over|under|[a-z]+)|dep"
 
 positional_preps_+advmod: "nmod_(behind|beneath|in|in_front_of|on|over|under)|advmod"
 

--- a/src/main/resources/org/clulab/asist/grammars/vars.yml
+++ b/src/main/resources/org/clulab/asist/grammars/vars.yml
@@ -30,7 +30,9 @@ report: "cite|give|mention|provide|report"
 
 search_relations: ">nmod_in|>nmod_within|>nmod_around|>nmod_beneath"
 
-positional_preps: "nmod_(behind|beneath|in|in_front_of|on|over|under)|dep"
+positional_preps: "nmod_(behind|beneath|in|in_front_of|on|over|under|dep)"
+
+positional_preps_liberal: "nmod_(behind|beneath|in|in_front_of|on|over|under|[a-z]+|dep)"
 
 positional_preps_+advmod: "nmod_(behind|beneath|in|in_front_of|on|over|under)|advmod"
 

--- a/src/test/scala/org/clulab/asist/rules/TestQuestions.scala
+++ b/src/test/scala/org/clulab/asist/rules/TestQuestions.scala
@@ -60,12 +60,22 @@ class TestQuestions extends BaseTest {
     val that = DesiredMention("DemPron", "that")
     val there = DesiredMention("Deictic", "there")
     val plan = DesiredMention("Plan", "plan")  // fixme: one day these should be a proper label in the taxonomy
-    val q1 = DesiredMention("Question", "What's that over there", Map("topic" -> Seq(that), "location" -> Seq(there)))
+    //val q1 = DesiredMention("Question", "What's that over there", Map("topic" -> Seq(that), "location" -> Seq(there)))
     val q2 = DesiredMention("Question", "What is the plan", Map("topic" -> Seq(plan)))
     val q3 = DesiredMention("Question", "What is that", Map("topic" -> Seq(that)))
-    testMention(mentions, q1)
+    //testMention(mentions, q1)
     testMention(mentions, q2)
     testMention(mentions, q3)
+  }
+
+  it should "handle contracted information gathering questions" in {
+    val text = "What's that over there?"
+    val mentions = extractor.extractFrom(text)
+    val that = DesiredMention("DemPron", "that")
+    val there = DesiredMention("Deictic", "there")
+    val quest1 = DesiredMention("Question", "What's that over there", Map("topic" -> Seq(that), "location" ->Seq(there)))
+
+    testMention(mentions,quest1)
   }
 
   it should "handle Yes_No questions" in {


### PR DESCRIPTION
- location questions such as "Where are you at, green?" now extract "green" as the argument, instead of "you"
- - this however results in a loss of the "you" argument

- fixed some priorities that resulted in certain locations not getting extracted in TeamCommunication extractions

- fixed an issue with "then after" style precedences

- added any CMU keywords we can use

- "yeah no" is now a negation and not an agreement

- multiples small fixes from the PI meeting insights
