### PR TITLE
Replacing default label with all labels in JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ message bus.
 ```json
 {
   "header": {
-    "timestamp": "2021-10-05T17:09:53.184Z",
+    "timestamp": "2021-10-07T18:27:42.843Z",
     "message_type": "event",
     "version": "2.3.0"
   },
   "msg": {
     "experiment_id": "367624f8-81cd-4661-a03f-b61908c39581",
     "trial_id": "78822ceb-448a-436e-a1f1-f154f2066261",
-    "timestamp": "2021-10-05T17:09:53.184Z",
+    "timestamp": "2021-10-07T18:27:42.843Z",
     "source": "tomcat_textAnalyzer",
     "sub_type": "Event:dialogue_event",
     "version": "2.3.0",
@@ -196,7 +196,7 @@ message bus.
   "data": {
     "participant_id": "P00012",
     "asr_msg_id": "bc36d1aa-25e6-11ec-ab58-7831c1b845fe",
-    "text": "I'm going to save this critical victim.",
+    "text": "I'm going to room 204.",
     "dialog_act_label": null,
     "utterance_source": {
       "source_type": "message_bus",
@@ -204,37 +204,102 @@ message bus.
     },
     "extractions": [
       {
-        "label": "CriticalVictim",
-        "span": "critical victim",
-        "arguments": {},
-        "attachments": [],
-        "start_offset": 23,
-        "end_offset": 38,
-        "rule": "critical_victim"
-      },
-      {
-        "label": "Save",
-        "span": "save this critical victim",
+        "labels": [
+          "MoveTo",
+          "Move",
+          "SimpleActions",
+          "Action",
+          "EventLike",
+          "Concept"
+        ],
+        "span": "going to room 204",
         "arguments": {
           "target": [
             {
-              "label": "CriticalVictim",
-              "span": "critical victim",
-              "arguments": {},
+              "labels": [
+                "NumberedRoom",
+                "Room",
+                "Infrastructure",
+                "Location",
+                "EventLike",
+                "Concept"
+              ],
+              "span": "room 204",
+              "arguments": {
+                "number": [
+                  {
+                    "labels": [
+                      "Number",
+                      "Concept"
+                    ],
+                    "span": "204",
+                    "arguments": {},
+                    "attachments": [],
+                    "start_offset": 18,
+                    "end_offset": 21,
+                    "rule": "numbers"
+                  }
+                ]
+              },
               "attachments": [],
-              "start_offset": 23,
-              "end_offset": 38,
-              "rule": "critical_victim"
+              "start_offset": 13,
+              "end_offset": 21,
+              "rule": "room_numbered"
             }
           ]
         },
         "attachments": [
-          "{\"text\":\"I\",\"agentType\":\"Self\",\"labels\":[\"Self\",\"Entity\",\"Concept\"],\"span\":[0]}",
-          "{\"value\":\"future\"}"
+          "{\"text\":\"I\",\"agentType\":\"Self\",\"labels\":[\"Self\",\"Entity\",\"Concept\"],\"span\":[0]}"
         ],
+        "start_offset": 4,
+        "end_offset": 21,
+        "rule": "move_nmod_action"
+      },
+      {
+        "labels": [
+          "NumberedRoom",
+          "Room",
+          "Infrastructure",
+          "Location",
+          "EventLike",
+          "Concept"
+        ],
+        "span": "room 204",
+        "arguments": {
+          "number": [
+            {
+              "labels": [
+                "Number",
+                "Concept"
+              ],
+              "span": "204",
+              "arguments": {},
+              "attachments": [],
+              "start_offset": 18,
+              "end_offset": 21,
+              "rule": "numbers"
+            }
+          ]
+        },
+        "attachments": [],
         "start_offset": 13,
-        "end_offset": 38,
-        "rule": "triage"
+        "end_offset": 21,
+        "rule": "room_numbered"
+      },
+      {
+        "labels": [
+          "Room",
+          "Infrastructure",
+          "Location",
+          "EventLike",
+          "Concept"
+        ],
+        "span": "room",
+        "arguments": {},
+        "attachments": [],
+        "start_offset": 13,
+        "end_offset": 17,
+        "rule": "room_detection"
       }
     ]
   }

--- a/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
@@ -202,7 +202,7 @@ class DialogAgent (
     } yield (role, converted)
     val extractionAttachments = mention.attachments.map(write(_))
     DialogAgentMessageUtteranceExtraction(
-      mention.label,
+      mention.labels,
       mention.words.mkString(" "),
       extractionArguments.toMap,
       extractionAttachments,

--- a/src/main/scala/org/clulab/asist/messages/DialogAgentMessage.scala
+++ b/src/main/scala/org/clulab/asist/messages/DialogAgentMessage.scala
@@ -21,7 +21,7 @@ case class DialogAgentMessageUtteranceSource(
 
 /** Part of the DialogAgentMessageData class */
 case class DialogAgentMessageUtteranceExtraction(
-  label: String = null,
+  labels: Seq[String] = Seq.empty,
   span: String = null,
   arguments: Map[String, Seq[DialogAgentMessageUtteranceExtraction]] = Map.empty,
   attachments: Set[String] = Set.empty, // Json strings

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.3.0"
+version in ThisBuild := "3.0.0"


### PR DESCRIPTION
- Instead of outputing just the label corresponding to the leaf node in
  the taxonomy, we now output all the labels in the hierarchy. This
  enables analyses at different levels of abstraction. For example,
  instead of checking for 'MoveTo' labels, you could check for 'Move'
  labels as well for a more coarse-grained approach, since 'MoveTo'
  falls under the 'Move' node.
- Bumping version to 3.0.0 since this is a backwards-incompatible change
  in the JSON format. If you were accessing the labels like
  `data["extractions"][0]["label"]`, you would now do
  `data["extractions"][0]["label"][0]` to get the default label.