### PR TITLE
Minor improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,3 @@ jobs:
     # SBT testing
     - name: SBT Test
       run:  sbt test
-
-    # SBT WebApp testing
-    - name: SBT Webapp Test
-      run:  sbt webapp/run
-

--- a/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
@@ -72,7 +72,6 @@ class DialogAgent (
 
   // Create the engine and run it to get lazy init out of the way 
   logger.info("Initializing Extractor (this may take a few seconds) ...")
-  //val engine = new TomcatRuleEngine()
   engine.extractFrom("green victim")
   logger.info("Extractor initialized.")
 
@@ -81,8 +80,7 @@ class DialogAgent (
    */
   def commonHeader(timestamp: String): CommonHeader = CommonHeader(
     timestamp = timestamp,
-    message_type = dialogAgentMessageType,
-    version = dialogAgentVersion
+    message_type = dialogAgentMessageType
   )
 
   /** Create a CommonMsg data structure 

--- a/src/main/scala/org/clulab/asist/messages/Common.scala
+++ b/src/main/scala/org/clulab/asist/messages/Common.scala
@@ -13,7 +13,7 @@ package org.clulab.asist.messages
 case class CommonHeader(
   timestamp: String = null, // "2019-12-26T12:47:23.1234Z"
   message_type: String = null, // "event"
-  version: String = null // "1.0"
+  version: String = "1.1" // Should track the common header version in the Aptima Gitlab repo
 )
 
 /* This is not the complete CommonMsg struct, it only contains the fields we use

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -106,7 +106,7 @@ class HomeController @Inject() (cc: ControllerComponents)
     )
     val timestamp = Clock.systemUTC.instant.toString
     val message = DialogAgentMessage(
-      CommonHeader(timestamp, agent.dialogAgentMessageType, agent.dialogAgentVersion),
+      CommonHeader(timestamp, agent.dialogAgentMessageType),
       CommonMsg(
         experiment_id = "367624f8-81cd-4661-a03f-b61908c39581",
         trial_id = "78822ceb-448a-436e-a1f1-f154f2066261",


### PR DESCRIPTION
- Hardcoding the version number in the common message header to track the TA3 version
- Removing webapp testing from CI since it apparently doesn't actually
  check it properly.