### PR TITLE
fixes for Instruction label

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -8,7 +8,7 @@ rules:
     example: "Help him!"
     keep: true
     pattern: |
-      trigger = (?<! (I|[tag=MD]|to) []*) [tag=VB & mention=Action] (?! []* I)
+      trigger = (?<! ((I|[tag=/^MD$|^WP$|^WRB$/]|to|[lemma=do]you) []*)) [tag=VB & mention=Action] (?! []* I)
       agent: Entity? = >/^nsubj/ [!mention=Self]
 
   - name: instruction_command_topic
@@ -16,7 +16,7 @@ rules:
     label: Instruction
     example: "Help him save the victim!"
     pattern: |
-      trigger = (?<! I []*) [tag=VB] (?! []* I)
+      trigger = (?<! ((I|[tag=/^MD$|^WP$|^WRB$/]|to) []*)) [tag=VB & mention=Action] (?! []* I)
       agent: Entity? = >/^nsubj/ [!mention=Self]
       topic: Action = >/dobj|ccomp/
 


### PR DESCRIPTION
various small fixes aimed at stopping the Instruction label from over matching

Prevents overmatching in cases of WH-questions and Yes-No Questions

for example: "Can you take two?" here the "take" was extracted as an Instruction

these cases were fixed with a series of negative lookbehinds