### PR TITLE
Deploying autogenerated docs to clulab.github.io/tomcat-text

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Deploy website to Github Pages
 on:
   push:
     branches: 
-      - docs
+      - master
 
 jobs:
   deploy_docs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         sudo apt-get install -y pandoc
         make htmldoc
+        mv extraction_schemas.html index.html
 
     - name: Deploy docs to clulab.github.io/tomcat-text
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Deploy website to Github Pages
+
+on:
+  push:
+    branches: 
+      - docs
+
+jobs:
+  deploy_docs:
+    runs-on: [ ubuntu-20.04 ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '8.0.232'
+
+    - name: Build docs
+      run: |
+        sudo apt-get install -y pandoc
+        make htmldoc
+
+    - name: Deploy docs to clulab.github.io/tomcat-text
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        publish_dir: .

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains natural language text processing code for the DARPA
 Artificial Social Intelligence for Successful Teams (ASIST) program. See the
 main ToMCAT project page for more information: https://ml4ai.github.io/tomcat.
 
+For documentation on the entities and events being extracted by the master
+branch version of the code, please see https://clulab.github.io/tomcat-text.
 
 # Web App
 

--- a/scripts/build_docs
+++ b/scripts/build_docs
@@ -3,4 +3,4 @@
 # Script to automatically generate extraction and rule schemas
 
 # Generate markdown documentation
-sbt "runMain org.clulab.asist.RunGrammarDemo . /org/clulab/asist/grammars/master.yml"
+sbt "runMain org.clulab.asist.apps.RunGrammarDemo . /org/clulab/asist/grammars/master.yml"


### PR DESCRIPTION
This PR implements deploying autogenerated extraction documentation to https://clulab.github.io/tomcat-text.