### PR TITLE
HeartbeatProducer now reads beat interval from config

### DIFF
--- a/src/main/scala/org/clulab/asist/agents/HeartbeatProducer.scala
+++ b/src/main/scala/org/clulab/asist/agents/HeartbeatProducer.scala
@@ -38,7 +38,7 @@ class HeartbeatProducer(agent: DialogAgentMqtt) extends LazyLogging {
   // published only if defined.
   private val topicHeartbeat: String = agent.topicPubHeartbeat
   private val startSeconds: Long = 0
-  private val beatSeconds: Long = agent.config.getInt("DialogAgent.heartbeatSeconds")
+  private val beatSeconds: Long = agent.config.getInt("MqttAgent.heartbeatSeconds")
   system.scheduler.scheduleWithFixedDelay(
     startSeconds seconds, 
     beatSeconds seconds


### PR DESCRIPTION
The HeatbeatProducer was looking at the old config struct, this is now fixed.