### PR TITLE
Trial 'start' and 'stop' values are now set in the config file

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -88,7 +88,10 @@ Trial {
     message_type = "trial"
   }
   msg {
-    sub_type = "versioninfo"  // actually "start" and "stop"
+    sub_type{
+      trial_start = "start"
+      trial_stop = "stop"
+    }
   }
 }
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -40,6 +40,8 @@ class DialogAgentMqtt(
   val heartbeatProducer = new HeartbeatProducer(this)
 
   val source_type = "message_bus"
+  val trial_start = config.getString("Trial.msg.sub_type.trial_start")
+  val trial_stop = config.getString("Trial.msg.sub_type.trial_stop")
 
   // create the IDC worker if required
   val idcWorker: Option[IdcWorker] = 
@@ -53,7 +55,7 @@ class DialogAgentMqtt(
     trialMessage.msg.sub_type match {
 
       // trial start message, reset the TDAC and start heartbeat
-      case "start" =>
+      case `trial_start` =>
         idcWorker.foreach(_.reset)
         val currentTimestamp = Clock.systemUTC.instant.toString
         val versionInfo = VersionInfo(config, trialMessage, currentTimestamp)
@@ -69,7 +71,7 @@ class DialogAgentMqtt(
         heartbeatProducer.start(trialMessage)
 
       // trial stop message, stop heartbeat
-      case "stop" =>
+      case `trial_stop` =>
         heartbeatProducer.stop 
         finishJob
 

--- a/src/main/scala/org/clulab/asist/messages/VersionInfo.scala
+++ b/src/main/scala/org/clulab/asist/messages/VersionInfo.scala
@@ -127,7 +127,12 @@ object VersionInfo
           VersionInfoDataMessageChannel(
             config.getString("Trial.topic"),
             config.getString("Trial.header.message_type"),
-            config.getString("Trial.msg.sub_type")
+            config.getString("Trial.msg.sub_type.trial_start")
+          ),
+          VersionInfoDataMessageChannel(
+            config.getString("Trial.topic"),
+            config.getString("Trial.header.message_type"),
+            config.getString("Trial.msg.sub_type.trial_stop")
           ),
           VersionInfoDataMessageChannel(
             config.getString("Asr.topic"),


### PR DESCRIPTION
Config file 'application.conf' now completely defines the Trial start and stop fields