### PR TITLE
Threat room

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,7 +5,7 @@ TomcatRuleEngine {
 // Override the default values here
       masterRulesPath = "/org/clulab/asist/grammars/master.yml"
 //    entityRulesPath =
-//     avoidRulesPath = 
+//     avoidRulesPath =
 //       taxonomyPath =
 //            maxHops =
 //      wordToVecPath =

--- a/src/main/resources/org/clulab/asist/grammars/items.yml
+++ b/src/main/resources/org/clulab/asist/grammars/items.yml
@@ -81,7 +81,7 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)^threat/] [lemma=room]? [lemma=marker] [lemma=block]? | [lemma=/(?i)^threat/] [lemma=room]? [lemma=markerblock]
+      [lemma=/(?i)^threat/] [lemma=room]? [lemma=marker] [lemma=block]? | [lemma=/(?i)^threat/] [lemma=room]? [lemma=markerblock] | [word=/(?i)^threatmarker/]
 
 # -------- map objects ----------
 
@@ -91,4 +91,12 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)^threat/] [lemma=/^sign/] | [lemma=/(?i)threatsign/]
+      [lemma=/(?i)^threat/] [lemma=/^sign|^indicator/] | [lemma=/(?i)threatsign/]
+
+  - name: threat_sign_token_unspecified
+    priority: ${ rulepriority }
+    label: Threat
+    type: token
+    keep: false
+    pattern: |
+      [lemma=/(?i)^threat/]

--- a/src/main/resources/org/clulab/asist/grammars/items.yml
+++ b/src/main/resources/org/clulab/asist/grammars/items.yml
@@ -86,6 +86,7 @@ rules:
 # -------- map objects ----------
 
   - name: threat_sign_token
+    example: "I have a threatsign on my map"
     priority: ${ rulepriority }
     label: ThreatSign
     type: token

--- a/src/main/resources/org/clulab/asist/grammars/items.yml
+++ b/src/main/resources/org/clulab/asist/grammars/items.yml
@@ -74,3 +74,21 @@ rules:
     keep: true
     pattern: |
       [lemma=/(?i)empty/] [lemma=marker] [lemma=block]?
+
+  - name: threatmarker
+    priority: ${ rulepriority }
+    label: ThreatRoomMarker
+    type: token
+    keep: true
+    pattern: |
+      [lemma=/(?i)^threat/] [lemma=room]? [lemma=marker] [lemma=block]? | [lemma=/(?i)^threat/] [lemma=room]? [lemma=markerblock]
+
+# -------- map objects ----------
+
+  - name: threat_sign_token
+    priority: ${ rulepriority }
+    label: ThreatSign
+    type: token
+    keep: true
+    pattern: |
+      [lemma=/(?i)^threat/] [lemma=/^sign/] | [lemma=/(?i)threatsign/]

--- a/src/main/resources/org/clulab/asist/grammars/locations.yml
+++ b/src/main/resources/org/clulab/asist/grammars/locations.yml
@@ -159,3 +159,11 @@ rules:
     type: token
     pattern: |
       [mention=Location]{2,4}
+
+  - name: threat_room_toke
+    priority: ${ second_priority }
+    label: ThreatRoom
+    type: token
+    keep: true
+    pattern: |
+      [word=/(?i)^threat$/] [word=/(?i)^room/] | [word=/(?i)^threatroom/]

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -219,7 +219,8 @@
       - MedKit
       - Stretcher
       - Map:
-          - ThreatSign
+          - ThreatSign:
+              - Threat
   - Sentiment:
     #- Uncertainty  # include the agent
     - Positive:

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -212,14 +212,14 @@
         - RegularMarkerBlock
         - NoVictimMarkerBlock
         - CriticalMarkerBlock
-        - ThreatRoomMarker
+        - ThreatRoomMarker #this refers to the actual marker block
         - RubbleMarker
     - Tool:
       - Hammer
       - MedKit
       - Stretcher
       - Map:
-          - ThreatSign:
+          - ThreatSign: #this refers to the sign on the map!
               - Threat
   - Sentiment:
     #- Uncertainty  # include the agent

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -137,6 +137,7 @@
             - RoleDeclare
             - RoomStatus:
                 - RoomClear
+                - ReportThreatRoom
             - ReportItemStatus:
               - ToolBroken
               - DoorOpen

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -211,11 +211,14 @@
         - RegularMarkerBlock
         - NoVictimMarkerBlock
         - CriticalMarkerBlock
+        - ThreatRoomMarker
+        - RubbleMarker
     - Tool:
       - Hammer
       - MedKit
       - Stretcher
-      - Map
+      - Map:
+          - ThreatSign
   - Sentiment:
     #- Uncertainty  # include the agent
     - Positive:

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -14,6 +14,7 @@
         - Deictic
       - Infrastructure:
         - Room:
+            - ThreatRoom
           # Study 3
             - A1
             - A2

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -115,6 +115,26 @@ rules:
         </cop/
         >/nsubj/
 
+  - name: threatroom_report2
+    priority: ${ rulepriority }
+    example: "B3 has a threat sign"
+    label: ReportThreatRoom
+    pattern: |
+      trigger = [tag=/^VB/]
+      threat: ThreatSign = >/dobj/
+      room: Room =
+        >/nsubj/
+
+  - name: threatroom_report3
+    priority: ${ rulepriority }
+    example: "B3 has a threat marker"
+    label: ReportThreatRoom
+    pattern: |
+      trigger = [tag=/^VB/]
+      threat: ThreatRoomMarker = >/dobj/
+      room: Room =
+        >/nsubj/
+
   - name: location_report
     priority: ${ rulepriority }
     example: "I'm in the library"

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -117,11 +117,11 @@ rules:
 
   - name: threatroom_report2
     priority: ${ rulepriority }
-    example: "B3 has a threat sign"
+    example: "B3 has a threat sign| C3 is marked as a threat"
     label: ReportThreatRoom
     pattern: |
       trigger = [tag=/^VB/]
-      threat: ThreatSign = >/dobj/
+      threat: ThreatSign = >/dobj|nmod/
       room: Room =
         >/nsubj/
 

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -104,6 +104,17 @@ rules:
       agent: Entity? = >/(${agents})/
       target: Role = >/nmod_to/
 
+  - name: threatroom_report1
+    priority: ${ rulepriority }
+    example: "B3 is a threat room"
+    label: ReportThreatRoom
+    pattern: |
+      trigger = [lemma=/(?i)^(${ exist_triggers })/]
+      threat: ThreatRoom = </cop/ [!outgoing=aux] # prevent things like "I will be" or "I could be"
+      room: Room =
+        </cop/
+        >/nsubj/
+
   - name: location_report
     priority: ${ rulepriority }
     example: "I'm in the library"
@@ -111,7 +122,7 @@ rules:
     pattern: |
       trigger = [lemma=/(?i)^(${ exist_triggers })/]
       location: Location = </cop/ [!outgoing=aux] # prevent things like "I will be" or "I could be"
-      agent: Entity? =
+      agent: Entity =
         </cop/
         >/nsubj/
 


### PR DESCRIPTION
added various labels and rules surrounding players talking about threat signs, threat markers, and threat rooms

added a rule for players to report threat rooms (ReportThreatRoom) with instances such as:
""C3 is a threat room""
""C3 contains a threat""
""B2 has a threat sign""
"C2 is marked as a threat"
etc.

The KnowledgeSharing label covers instances such as:
"There is a threat in room B2" 
as expected
