### PR TITLE
Meeting fix, marker block updated

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -41,6 +41,16 @@ rules:
       location: Location? = >/${ positional_preps_+advmod }/
       agent: Entity? = >/${agents}/
 
+  - name: triage_get
+    priority: ${ rulepriority }
+    label: Save
+    example: "I will save the victim"
+    pattern: |
+      trigger = [word=get]
+      target: Victim = >dobj
+      location: Location? = >/${ positional_preps_+advmod }/
+      agent: Entity? = >/${agents}/
+
   - name: triage2
     priority: ${ rulepriority }
     label: Save

--- a/src/main/resources/org/clulab/asist/grammars/marker_blocks.yml
+++ b/src/main/resources/org/clulab/asist/grammars/marker_blocks.yml
@@ -1,10 +1,10 @@
 - name: marker_block
-  priority: ${ rulepriority }
+  priority: ${ second_priority }
   label: MarkerBlock
   type: token
   keep: true
   pattern: |
-    [lemma=/(?i)marker/] [lemma=block]?
+    [lemma=/(?i)marker/ & !mention=MarkerBlock] [lemma=block]?
 
 - name: critical_marker_token
   priority: ${ rulepriority }
@@ -37,3 +37,32 @@
   keep: true
   pattern: |
     [lemma=/(?i)^threat/] [lemma=room]? [lemma=marker] [lemma=block]? | [lemma=/(?i)^threat/] [lemma=room]? [lemma=markerblock] | [word=/(?i)^threatmarker/]
+
+- name: type_A_marker
+  priority: ${ rulepriority }
+  label: TypeAMarker
+  type: token
+  keep: true
+  pattern: |
+    [lemma=/(?i)\ba\b/] [word=type] [word=marker] [word=block]? (?! [word=/(?i)b.?/]|[word=/(?i)a/]|[word=/(?i)c/]|[word=see]) |
+    [word=marker] [word=block]? []? [word=type] [lemma=/(?i)\ba\b/] | [word=type] [lemma=/(?i)\ba\b/] [word=marker] [word=block]? (?! [word=/(?i)b.?/]|[word=/(?i)a/]|[word=/(?i)c/]|[word=see])
+
+
+- name: type_B_marker
+  priority: ${ rulepriority }
+  label: TypeBMarker
+  type: token
+  keep: true
+  pattern: |
+    [lemma=/(?i)\bb\b/] [word=type] [word=marker] [word=block]? (?! [word=/(?i)b.?/]|[word=/(?i)a/]|[word=/(?i)c/]|[word=see]) |
+    [word=marker] [word=block]? []? [word=type] [lemma=/(?i)\bb\b/] | [word=type] [lemma=/(?i)\bb\b/] [word=marker] [word=block]? (?! [word=/(?i)b.?/]|[word=/(?i)a/]|[word=/(?i)c/]|[word=see])
+
+
+- name: rubble_marker
+  priority: ${ rulepriority }
+  label: RubbleMarker
+  type: token
+  keep: true
+  pattern: |
+    @Rubble [word=marker] [word=block]? (?! [word=/(?i)b.?/]|[word=/(?i)a/]|[word=/(?i)c/]|[word=see]) |
+    [word=marker] [word=block]? []? @Rubble

--- a/src/main/resources/org/clulab/asist/grammars/master.yml
+++ b/src/main/resources/org/clulab/asist/grammars/master.yml
@@ -29,6 +29,7 @@ rules:
   - import: org/clulab/asist/grammars/items.yml
     vars:
       rulepriority: "3+"
+      second_priority: "5+"
 
   # Extract the sentiments
   - import: org/clulab/asist/grammars/sentiments.yml

--- a/src/main/resources/org/clulab/asist/grammars/puzzle_concepts.yml
+++ b/src/main/resources/org/clulab/asist/grammars/puzzle_concepts.yml
@@ -12,7 +12,7 @@ rules:
 
   - name: lunch_token
     priority: ${ rulepriority }
-    label: Lunch
+    label: Meeting
     pattern: |
       trigger= [lemma=/(?i)^lunch/]
       location: Location?= <nsubj >/.*/ | >nmod_in
@@ -20,7 +20,7 @@ rules:
 
   - name: training_token
     priority: ${ rulepriority }
-    label: Training
+    label: Meeting
     pattern: |
       trigger= [lemma=/(?i)^training/] | [word=/(?i)^training/]
       location: Location?= <nsubj >/.*/ | >nmod_in

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -215,7 +215,9 @@
       - West
   - Item:
     - MarkerBlock:
-        - RegularMarkerBlock
+        - RegularMarkerBlock:
+            - TypeAMarker
+            - TypeBMarker
         - NoVictimMarkerBlock
         - CriticalMarkerBlock
         - ThreatRoomMarker #this refers to the actual marker block
@@ -237,9 +239,7 @@
       #- Anger
       #- Worry
   - PuzzleConcept:
-      - Meeting
-      - Lunch
-      - Training
+      - Meeting # this is for all occurences of lunch, training, meeting
       - Damage:
           - MildDamage
           - ModerateDamage

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -289,6 +289,18 @@ rules:
                >/${preps}/|
                >/advmod/
 
+  - name: found_victim_got
+    priority: ${ rulepriority }
+    label: KnowledgeSharing
+    example: "I have a victim here"
+    pattern: |
+      trigger =[word=/(?i)got$/]
+      exists: Victim = >/${objects}/
+      location: Location? = >/${objects}/ >/advmod/|
+               >/${objects}/ >/${preps}/|
+               >/${preps}/|
+               >/advmod/
+
 
 
   - name: room_clear

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -105,7 +105,7 @@ toggle_triggers: "flip|toggle|turn|switch|pull|open"
 
 transpose_triggers: "move|shift"
 
-triage_triggers: "save|triage|heal|help|get|rescue"
+triage_triggers: "save|triage|heal|help|rescue"
 
 triage_triggers_strict: "save|triage|heal|rescue"
 


### PR DESCRIPTION
mentions of meetings, trainings, and lunches are now extracted under the Meeting label.
This is a subset of the PuzzleConcept label, which also houses the labels for Mild, Moderate, and SevereDamage regarding these puzzle rooms

All study 3 marker blocks are enabled, check the MarkerBlock subset of labels in the taxonomy for more information

This should conclude any updates for new study3 content, as far as I am aware, we now have labels for all new relevant concepts