### PR TITLE
Idc work

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/entities.yml
+++ b/src/main/resources/org/clulab/asist/grammars/entities.yml
@@ -30,6 +30,14 @@ rules:
       label: Rubble
       trigger: ${ rubble_triggers }
 
+  - name: rubble_stuff
+    label: Rubble
+    priority: ${ rulepriority }
+    type: token
+    keep: false
+    pattern: |
+      [lemma=/(?i)^stuff$/]
+
   - import: org/clulab/asist/grammars/ent_template.yml
     vars:
       name: fire

--- a/src/main/resources/org/clulab/asist/grammars/sentiments.yml
+++ b/src/main/resources/org/clulab/asist/grammars/sentiments.yml
@@ -32,7 +32,32 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)^(${ agree_triggers })$/] (?!no)
+      (?<! [lemma=be] []? ) [lemma=/(?i)^(${ agree_triggers })$/] (?!no)
+
+  - name: agree_token_match_adjectives
+    label: Agreement
+    priority: ${ rulepriority }
+    type: token
+    keep: true
+    pattern: |
+      (?<! [lemma=be] []? ) [lemma=/(?i)^(${ agree_adjectives })$/] (?! no|[tag=NN]|[tag=RB]  )
+
+  - name: agree_token_sure
+    label: Agreement
+    priority: ${ rulepriority }
+    type: token
+    keep: true
+    pattern: |
+      [lemma=/(?i)^sure$/] (?! [][])
+
+  - name: agree_token_sure2
+    example: "Sure, I can help"
+    label: Agreement
+    priority: ${ rulepriority }
+    type: token
+    keep: true
+    pattern: |
+      [lemma=/(?i)^sure$/] (?= /\.|,|\!/)
 
   - name: disagree_token_match
     label: Disagreement
@@ -42,6 +67,13 @@ rules:
     pattern: |
       [lemma=/(?i)^(${ disagree_triggers })$/ & !tag=TO] (?! [lemma=victim])
 
+  - name: no_token_match
+    label: Disagreement
+    priority: ${ rulepriority }
+    type: token
+    keep: true
+    pattern: |
+      [word=/(?i)^no$/ & !tag=TO] (?! [lemma=victim]|[word=worries]|[word=more]|[tag=JJ]|[tag=NN])
 
   - name: thank_you
     label: Gratitude

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -8,17 +8,33 @@ rules:
     example: "Help him!"
     keep: true
     pattern: |
-      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !mention=Instruction] (?! [lemma=not][lemma=worry]|(you)|([]* I))
+      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !mention=Instruction & !lemma=let] (?! [][][]|[tag=/\./]|[lemma=not][lemma=worry]|(you)|([]* I))
       agent: Entity? = >/^nsubj/ [!mention=Self]
 
+  - name: instruction_let
+    priority: ${ rulepriority }
+    label: Instruction
+    example: "Let's go"
+    keep: true
+    pattern: |
+      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !mention=Instruction & lemma=let] (?! me|[lemma=not][lemma=worry]|(you)|([]* I))
+      agent: Entity? = >/^nsubj/ [!mention=Self]
 
+  - name: instruction_command_topic_let
+    priority: ${ rulepriority }
+    label: Instruction
+    example: "Help him save the victim! Don't enter D2."
+    pattern: |
+      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & lemma=let] (?! me|(you)|([]* I))
+      agent: Entity? = >/^nsubj/ [!mention=Self]
+      topic: Action = >/dobj|ccomp/ [!mention=Instruction] | <aux [!mention=Instruction]
 
   - name: instruction_command_topic
     priority: ${ rulepriority }
     label: Instruction
     example: "Help him save the victim! Don't enter D2."
     pattern: |
-      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action] (?! (you)|([]* I))
+      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !lemma=let] (?! (you)|([]* I))
       agent: Entity? = >/^nsubj/ [!mention=Self]
       topic: Action = >/dobj|ccomp/ | <aux
 

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -8,7 +8,7 @@ rules:
     example: "Help him!"
     keep: true
     pattern: |
-      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !mention=Instruction & !lemma=let] (?! [][][]|[tag=/\./]|[lemma=not][lemma=worry]|(you)|([]* I))
+      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !mention=Instruction & !lemma=let & !lemma=be] (?! [][][]|[tag=/\./]|[lemma=not][lemma=worry]|(you)|([]* I))
       agent: Entity? = >/^nsubj/ [!mention=Self]
 
   - name: instruction_let
@@ -17,7 +17,7 @@ rules:
     example: "Let's go"
     keep: true
     pattern: |
-      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !mention=Instruction & lemma=let] (?! me|[lemma=not][lemma=worry]|(you)|([]* I))
+      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !mention=Instruction & lemma=let & !lemma=be] (?! me|[lemma=not][lemma=worry]|(you)|([]* I))
       agent: Entity? = >/^nsubj/ [!mention=Self]
 
   - name: instruction_command_topic_let
@@ -34,7 +34,7 @@ rules:
     label: Instruction
     example: "Help him save the victim! Don't enter D2."
     pattern: |
-      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !lemma=let] (?! (you)|([]* I))
+      trigger = (?<! (I|[tag=/^MD$|^WP$|^WRB$|VBD$/]|to|[lemma=do]you|[lemma=do][lemma=not]|or|oh) []*) [tag=VB & mention=Action & !lemma=let & !lemma=be] (?! (you)|([]* I))
       agent: Entity? = >/^nsubj/ [!mention=Self]
       topic: Action = >/dobj|ccomp/ | <aux
 

--- a/src/main/resources/org/clulab/asist/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/asist/grammars/triggers.yml
@@ -1,6 +1,8 @@
 after_precedence_triggers: "after"
 
-agree_triggers: "yes|yeah|roger|acknowledge|ok|okay|agree|sure|alright|good|excellent|great|terrific|copy"
+agree_triggers: "yes|yeah|roger|acknowledge|ok|okay|agree|alright|copy"
+
+agree_adjectives: "good|excellent|great|terrific"
 
 attack_triggers: "kill|fight|beat|defeat|hit|attack"
 
@@ -25,7 +27,7 @@ deixis_triggers: "here|there"
 
 dem_pron_triggers: "this|that|those|these"
 
-disagree_triggers: "no|nah|nope|negative"
+disagree_triggers: "nah|nope|negative"
 
 east_triggers: "east"
 
@@ -75,7 +77,7 @@ room_twoword_first_word_regex: "(cubicle|sundollar|Herbalife|limping lamb|lamb|s
 
 room_twoword_second_word_regex: "(room|cafe|office|terrace|area|storage|coffee|chophouse)"
 
-rubble_triggers: "rubble|blockage|pile|stuff|obstacle|barricade|rebel|gravel|pile"
+rubble_triggers: "rubble|blockage|pile|obstacle|barricade|rebel|gravel"
 
 search_spec_triggers: "search|service|searcher|scout"
 

--- a/src/main/resources/org/clulab/asist/grammars/victims.yml
+++ b/src/main/resources/org/clulab/asist/grammars/victims.yml
@@ -67,8 +67,8 @@ rules:
     type: token
     keep: true
     pattern: |
-     [word=/(?i)\b(b.?)|P\b/] [word=type] [lemma=/(?i)(${ victim_triggers })/]? | [lemma=type] [word=/(?i)\b(b.?)|P\b/] [lemma=/(?i)(${ victim_triggers })/]? |
-      [lemma=/(?i)(${ victim_triggers })/]? [word=/(?i)\b(b.?)|P\b/] [word=type] |  [lemma=/(?i)(${ victim_triggers })/]? [lemma=type] [word=/(?i)\b(b.?)|P\b/]
+     [word=/(?i)\b(b.?)|P\b/] [word=of]? [word=type] [lemma=/(?i)(${ victim_triggers })/]? | [lemma=type] [word=/(?i)\b(b.?)|P\b/] [lemma=/(?i)(${ victim_triggers })/]? |
+      [lemma=/(?i)(${ victim_triggers })/]? [word=of]? [word=/(?i)\b(b.?)|P\b/] [word=type] |  [lemma=/(?i)(${ victim_triggers })/]? [lemma=type] [word=/(?i)\b(b.?)|P\b/]
 
   - name: victimA
     priority: ${ rulepriority }
@@ -76,8 +76,8 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)(${ victim_triggers })/]? [lemma=type] [lemma=/(?i)\ba\b/] | [lemma=type] [lemma=/(?i)\ba\b/] [lemma=/(?i)(${ victim_triggers })/]? |
-       [lemma=/(?i)(${ victim_triggers })/] [lemma=/(?i)\ba\b/] [word=type] |  [lemma=/(?i)\ba\b/] [word=type] [lemma=/(?i)(${ victim_triggers })/]
+      [lemma=/(?i)(${ victim_triggers })/]? [word=of]? [lemma=type] [lemma=/(?i)\ba\b/] | [lemma=type] [lemma=/(?i)\ba\b/] [lemma=/(?i)(${ victim_triggers })/]? |
+       [lemma=/(?i)(${ victim_triggers })/] [word=of]? [lemma=/(?i)\ba\b/] [word=type] |  [lemma=/(?i)\ba\b/] [word=type] [lemma=/(?i)(${ victim_triggers })/]
 
   - name: victimA_a_type
     priority: ${ rulepriority }
@@ -93,8 +93,8 @@ rules:
     type: token
     keep: true
     pattern: |
-      [lemma=/(?i)(${ victim_triggers })/]? [lemma=type] [lemma=/(?i)\b(c|see)\b/] | [lemma=type] [lemma=/(?i)\b(c|see)\b/] [lemma=/(?i)(${ victim_triggers })/]? |
-       [lemma=/(?i)(${ victim_triggers })/]? [lemma=/(?i)\b(c|see)\b/] [word=type] |  [lemma=/(?i)\b(c|see)\b/] [word=type] [lemma=/(?i)(${ victim_triggers })/]?
+      [lemma=/(?i)(${ victim_triggers })/]? [word=of]? [lemma=type] [lemma=/(?i)\b(c|see)\b/] | [lemma=type] [lemma=/(?i)\b(c|see)\b/] [lemma=/(?i)(${ victim_triggers })/]? |
+       [lemma=/(?i)(${ victim_triggers })/]? [word=of]? [lemma=/(?i)\b(c|see)\b/] [word=type] |  [lemma=/(?i)\b(c|see)\b/] [word=type] [lemma=/(?i)(${ victim_triggers })/]?
 
   - name: victim_type_extraction
     priority: ${ rulepriority }

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentFile.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentFile.scala
@@ -126,7 +126,7 @@ class DialogAgentFile(
     logger.info(
       s"Processing DialogAgentMessage, timestamp = ${m.header.timestamp}"
     )
-    idcWorker.foreach(_.enqueue(m.data.extractions))
+    idcWorker.foreach(_.enqueue(m.data.extractions,m.data.participant_id))
     val json = JsonUtils.writeJson(m)
     tdacClient match {
       case Some(tdac) =>

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -185,7 +185,7 @@ class DialogAgentMqtt(
   ): Unit = messageMaybe match {
     case Some(message) =>
       // get the IDC worker going if we have one
-      idcWorker.foreach(_.enqueue(message.data.extractions))
+      idcWorker.foreach(_.enqueue(message.data.extractions,message.data.participant_id))
 
       // send job to TDAC if we use it
       tdacClient match {

--- a/src/main/scala/org/clulab/asist/agents/IdcWorker.scala
+++ b/src/main/scala/org/clulab/asist/agents/IdcWorker.scala
@@ -36,7 +36,7 @@ class IdcWorker(
   def enqueue(
                extractions: Seq[DialogAgentMessageUtteranceExtraction]
              ): Unit = {
-    showState
+    //showState
     val busy = !queue.isEmpty
     val data = IdcData(extractions, IdcWorkerState(0))
     queue.enqueue(data)
@@ -70,11 +70,11 @@ class IdcWorker(
   def doSomeProcessing(data: IdcData): Unit = {
     val seconds = 2
     val extraction = data
-    logger.info(s"Starting processing of job for $seconds seconds ...")
-    whatis(data)
+    //logger.info(s"Starting processing of job for $seconds seconds ...")
+    //whatis(data)
     processUttQueue(data)
     logger.info(s"${utteranceQueue.size} extractions are being tracked")
-    checkLabelSeq(queueState = utteranceQueue,firstlabel = "CriticalVictim",secondlabel = "MoveTo")
+    //checkLabelSeq2(queueState = utteranceQueue,firstlabel = "CriticalVictim",secondlabel = "MoveTo")
 
     //Thread.sleep(seconds*1000)
   }
@@ -94,18 +94,29 @@ class IdcWorker(
 
 
   /** This method takes 3 args, a Queue and 2 labels. It then searches all objects in the queue for the first label. If the first label is found, it checks for the 2nd label.  */
-    /** Currently this method is "stupid" ie it onl checks whether both labels are present in the queue, regardless of order */
+    /** Currently this method is "stupid" ie it only checks whether both labels are present in the queue, regardless of order */
   def checkLabelSeq(queueState: Queue[Seq[DialogAgentMessageUtteranceExtraction]], firstlabel: String, secondlabel: String): Unit={
     for(vector: Seq[DialogAgentMessageUtteranceExtraction] <- queueState){
       if(lookForLabel(vector: Seq[DialogAgentMessageUtteranceExtraction],firstlabel)){
           logger.info("first label detected")
-        if(lookForLabel(vector: Seq[DialogAgentMessageUtteranceExtraction],firstlabel)){
+        if(lookForLabel(vector: Seq[DialogAgentMessageUtteranceExtraction],secondlabel)){
           logger.info(s"$firstlabel and $secondlabel sequence detected")
         }
       }
     }
   }
 
+  def checkLabelSeq2(queueState: Queue[Seq[DialogAgentMessageUtteranceExtraction]], firstlabel: String, secondlabel: String): Unit={
+    val vector: Seq[DialogAgentMessageUtteranceExtraction] = queueState.front // we define this value as the first position in the queue, which means the this is the oldest utterance in the queue
+    if(lookForLabel(vector: Seq[DialogAgentMessageUtteranceExtraction],firstlabel)) {
+      logger.info("first label detected")
+      for(extract: Seq[DialogAgentMessageUtteranceExtraction] <- queueState){
+        if(lookForLabel(extract: Seq[DialogAgentMessageUtteranceExtraction],secondlabel)) {
+          logger.info(s"$firstlabel and $secondlabel sequence detected")
+        }
+      }
+    }
+  }
 
   /** constructing a queue to keep track of utterances */
   var utteranceQueue: Queue[Seq[DialogAgentMessageUtteranceExtraction]] = new Queue

--- a/src/main/scala/org/clulab/asist/agents/IdcWorker.scala
+++ b/src/main/scala/org/clulab/asist/agents/IdcWorker.scala
@@ -102,8 +102,8 @@ class IdcWorker(
       logger.info("first label detected")
       for(extract: (Seq[DialogAgentMessageUtteranceExtraction],String) <- queueState){
         if(lookForLabel(extract._1: Seq[DialogAgentMessageUtteranceExtraction],secondlabel) && id_1 != extract._2) {
-          // we're checking the participant IDs to make sure this is not a player talking to themselves
           logger.info(s"$firstlabel and $secondlabel sequence detected")
+          // we're checking the participant IDs to make sure this is not a player talking to themselves
         }
       }
     }

--- a/src/main/scala/org/clulab/asist/agents/IdcWorker.scala
+++ b/src/main/scala/org/clulab/asist/agents/IdcWorker.scala
@@ -93,19 +93,7 @@ class IdcWorker(
   }
 
 
-  /** This method takes 3 args, a Queue and 2 labels. It then searches all objects in the queue for the first label. If the first label is found, it checks for the 2nd label.  */
-    /** Currently this method is "stupid" ie it only checks whether both labels are present in the queue, regardless of order */
-  def checkLabelSeq(queueState: Queue[Seq[DialogAgentMessageUtteranceExtraction]], firstlabel: String, secondlabel: String): Unit={
-    for(vector: Seq[DialogAgentMessageUtteranceExtraction] <- queueState){
-      if(lookForLabel(vector: Seq[DialogAgentMessageUtteranceExtraction],firstlabel)){
-          logger.info("first label detected")
-        if(lookForLabel(vector: Seq[DialogAgentMessageUtteranceExtraction],secondlabel)){
-          logger.info(s"$firstlabel and $secondlabel sequence detected")
-        }
-      }
-    }
-  }
-
+  /** This method takes 3 args, a Queue and 2 labels. It checks if the first item in the queue is the label. If it is, it also checks if any of the other items in the queue have this label  */
   def checkLabelSeq2(queueState: Queue[Seq[DialogAgentMessageUtteranceExtraction]], firstlabel: String, secondlabel: String): Unit={
     val vector: Seq[DialogAgentMessageUtteranceExtraction] = queueState.front // we define this value as the first position in the queue, which means the this is the oldest utterance in the queue
     if(lookForLabel(vector: Seq[DialogAgentMessageUtteranceExtraction],firstlabel)) {

--- a/src/main/scala/org/clulab/asist/agents/IdcWorker.scala
+++ b/src/main/scala/org/clulab/asist/agents/IdcWorker.scala
@@ -75,7 +75,7 @@ class IdcWorker(
     //whatis(data)
     processUttQueue(data)
     logger.info(s"${utteranceQueue.size} extractions are being tracked")
-    checkLabelSeq2(queueState = utteranceQueue,firstlabel = "CriticalVictim",secondlabel = "MoveTo")
+    //checkLabelSeq2(queueState = utteranceQueue,firstlabel = "CriticalVictim",secondlabel = "MoveTo")
 
     //Thread.sleep(seconds*1000)
   }

--- a/src/main/scala/org/clulab/asist/messages/Idc.scala
+++ b/src/main/scala/org/clulab/asist/messages/Idc.scala
@@ -9,7 +9,7 @@ package org.clulab.asist.messages
 // IDC processing data for one message
 case class IdcData(
   extractions: Seq[DialogAgentMessageUtteranceExtraction] = Seq(),
-  messageData: Seq[DialogAgentMessageData] = Seq(),
+  participantID: String = "N/A",
   state: IdcWorkerState // put anything at all here
 )
 

--- a/src/main/scala/org/clulab/asist/messages/Idc.scala
+++ b/src/main/scala/org/clulab/asist/messages/Idc.scala
@@ -9,6 +9,7 @@ package org.clulab.asist.messages
 // IDC processing data for one message
 case class IdcData(
   extractions: Seq[DialogAgentMessageUtteranceExtraction] = Seq(),
+  messageData: Seq[DialogAgentMessageData] = Seq(),
   state: IdcWorkerState // put anything at all here
 )
 


### PR DESCRIPTION
This is a PR for the idcWorker (please ignore all the Odin commits, they are already merged into master, I don't know why they're here, relevant commit is b383ea7).

This PR gives the idcWorker access to the participant_id of an utterance. We need this in order to make sure that players are not talking to themselves. I'm tagging @jastier as a reviewer because I had to make some changes to `org/clulab/asist/agents/DialogAgentMqtt.scala`, `org/clulab/asist/agents/DialogAgentFile.scala`, and `org/clulab/asist/messages/Idc.scala`.

All the relevant changes are in commit b383ea7.