### PR TITLE
The "Save" label is now a subset of "TriageInteractions"

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/actions.yml
+++ b/src/main/resources/org/clulab/asist/grammars/actions.yml
@@ -75,6 +75,47 @@ rules:
       agent: Entity? = >/${agents}/
 ## This one is not working right now, working on it -Remo
 
+  - name: stabilize_victim
+    priority: ${ rulepriority }
+    label: Stabilize
+    example: "I'm stabilizing this victim"
+    pattern: |
+      trigger = [lemma=/(?i)^stabilize/]
+      target: Victim = >dobj
+      location: Location? = >/${ positional_preps_+advmod }/
+      agent: Entity? = >/${agents}/
+
+  - name: stabilize_person
+    priority: ${ rulepriority }
+    label: Stabilize
+    example: "I'm stabilizing this guy"
+    pattern: |
+      trigger = [lemma=/(?i)^stabilize/]
+      target: Person = >dobj
+      location: Location? = >/${ positional_preps_+advmod }/
+      agent: Entity? = >/${agents}/
+
+
+  - name: wakeup
+    priority: ${ rulepriority }
+    label: WakeUp
+    example: "I'm waking this guy"
+    pattern: |
+      trigger = [lemma=/(?i)^wake/]
+      target: Person = >dobj
+      location: Location? = >/${ positional_preps_+advmod }/
+      agent: Entity? = >/${agents}/
+
+  - name: wakeup_victim
+    priority: ${ rulepriority }
+    label: WakeUp
+    example: "I'm waking this victim"
+    pattern: |
+      trigger = [lemma=/(?i)^wake/]
+      target: Victim = >dobj
+      location: Location? = >/${ positional_preps_+advmod }/
+      agent: Entity? = >/${agents}/
+
   - import: org/clulab/asist/grammars/lvo_template_no_passive.yml
     vars:
       name: search

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -128,7 +128,10 @@
         - Close
         - Push
         - Toggle
-        - Save
+        - TriageInteractions:
+          - Save
+          - WakeUp
+          - Stabilize
         - Sight
         - PlaceMarker
         - Communicate:


### PR DESCRIPTION
```
- TriageInteractions:
         - - Save
         - - WakeUp
         - - Stabilize
```

Added rules for players talking about "waking up" and "stabilizing" victims.

These labels are all under "TriageInteractions". If agents are not interested in the distinctions between "Stabilize", "WakeUp", and "Save", they can look for TriageInteractions