### PR TITLE
Dockerfile update

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,4 +1,4 @@
-from mozilla/sbt
+from mozilla/sbt:8u292_1.5.7
   
 copy . /tomcat-text
 workdir tomcat-text

--- a/scripts/deploy_to_gitlab
+++ b/scripts/deploy_to_gitlab
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # This script builds the dialog agent image and deploys it to the Aptima Gitlab
 # instance.
 


### PR DESCRIPTION
This PR updates `Dockerfile.agent` to fix a build error caused by the `mozilla/sbt` base image's latest version switching from Java 8 to Java 11. It also adds `set -e` to the top of the `deploy_to_gitlab` script.