### PR TITLE
Renamed Negation.value field to Negation.negation

### DIFF
--- a/src/main/scala/org/clulab/asist/attachments/Negation.scala
+++ b/src/main/scala/org/clulab/asist/attachments/Negation.scala
@@ -2,6 +2,6 @@ package org.clulab.asist.attachments
 
 import org.clulab.odin.Attachment
 
-case class Negation(value: Boolean = true) extends Attachment {
+case class Negation(negation: Boolean = true) extends Attachment {
 
 }


### PR DESCRIPTION
Renamed the 'value' field of the optional Negation class to 'negation'

