### PR TITLE
Add "could you take care of.." pattern to Instruction

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -44,8 +44,8 @@ rules:
     example: "Could you take care of the rubble, blue?"
     pattern: |
       trigger = [word=/(?i)^(Could|Will|Can|Would)/](you)(please?)(take care of)(?=[tag=/^DT?/])(?=[tag=/^N?/])
-      agent: Entity? = >/^nsubj/
-      topic: Action = >/dobj|ccomp/
+      agent: Entity? = </aux/ >/^nsubj/
+      topic: Action = </aux/
 
   - name: prep_need_role
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -38,6 +38,15 @@ rules:
       agent: Entity? = >/^nsubj/ [!mention=Self]
       topic: Action = >/dobj|ccomp/ | <aux
 
+  - name: instruction_take_care_of
+    priority: ${ rulepriority }
+    label: Instruction
+    example: "Could you take care of the rubble, blue?"
+    pattern: |
+      trigger = [word=/(?i)^(Could|Will|Can|Would)/](you)(please?)(take care of)(?=[tag=/^DT?/])(?=[tag=/^N?/])
+      agent: Entity? = >/^nsubj/
+      topic: Action = >/dobj|ccomp/
+
   - name: prep_need_role
     priority: ${ rulepriority }
     label: NeedRole


### PR DESCRIPTION
Hi Remo! Thank you for your help. I deleted my local repo and cloned again, start a new branch from the newest master and move my changes here. But I found the newest version of the repo could fail the sbt test. 
My previous pull request was asking that the pattern "Could you please take care of the rubble, blue." can by extracted by the Instruction rule when I write in Odin tutorial playground(screenshot below). But it is not extracted as "Instruction" in our webapp. I'm thinking, is this because the YesNoQuestion has a higher priority than instruction? 

![image](https://user-images.githubusercontent.com/60522232/162844833-daf9019e-4e21-40ca-9c0a-18b1cb06fd5f.png)
