### PR TITLE
Modelling team requests

### DIFF
--- a/src/main/resources/org/clulab/asist/grammars/master.yml
+++ b/src/main/resources/org/clulab/asist/grammars/master.yml
@@ -93,6 +93,7 @@ rules:
   - import: org/clulab/asist/grammars/team_communication.yml
     vars:
       rulepriority: "6+"
+      second_priority: "7+"
 
   # Extract temporal extractions
   - import: org/clulab/asist/grammars/temporal_extractions.yml

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -154,6 +154,7 @@
             - NeedAction
             - HelpRequest:
                 - AmTrapped
+          - HelpOffer
           - Question:
             - QuestionParticle
             - LocationQuestion

--- a/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/asist/grammars/taxonomy.yml
@@ -135,7 +135,8 @@
         - Sight
         - PlaceMarker
         - Communicate:
-          - Instruction
+          - Instruction:
+              - HelpCommand
           - ReportStatus:
             - Stuck
             - ReportLocation

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -373,3 +373,14 @@ rules:
       agent: Entity? = >/nsubj/
       location: Location? = >/${preps}/|
                >/advmod/
+
+  - name: "HelpOffer"
+    label: HelpOffer
+    example: "Let me help you. I will help you."
+    priority: ${ rulepriority }
+    pattern: |
+      trigger = [lemma=/assist|help|aid|support/]
+      agent: Entity = >nsubj|<xcomp >nsubj
+      helpee: Entity = >ccomp >nsubj | >ccomp | >dep | >dobj
+      location: Location? = >/${preps}/|
+               >/advmod/

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -380,7 +380,18 @@ rules:
     priority: ${ rulepriority }
     pattern: |
       trigger = [lemma=/assist|help|aid|support/]
-      agent: Entity = >nsubj|<xcomp >nsubj
+      agent: Self = >nsubj|<xcomp >nsubj
       helpee: Entity = >ccomp >nsubj | >ccomp | >dep | >dobj
+      location: Location? = >/${preps}/|
+               >/advmod/
+
+
+  - name: "HelpOffer_no_helpee"
+    label: HelpOffer
+    example: "Let me help. I will help."
+    priority: ${ rulepriority }
+    pattern: |
+      trigger = [lemma=/assist|help|aid|support/] [!mention=HelpOffer]
+      agent: Self = >nsubj|<xcomp >nsubj
       location: Location? = >/${preps}/|
                >/advmod/

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -347,7 +347,7 @@ rules:
     example: "I need help."
     priority: ${ rulepriority }
     pattern: |
-      trigger = [word=/(?i)need|require/] [word=/(?i)help|assistance/ & tag=/NN|^VB$/]
+      trigger = [word=/(?i)need|require/] []? [word=/(?i)help|assistance/ & tag=/NN|^VB$/]
       agent: Entity? = >/${agents}/
       location: Location? = >/${preps}/|
                >/advmod/
@@ -389,9 +389,31 @@ rules:
   - name: "HelpOffer_no_helpee"
     label: HelpOffer
     example: "Let me help. I will help."
+    priority: ${ second_priority }
+    pattern: |
+      trigger = [lemma=/assist|help|aid|support/ & !mention=HelpOffer]
+      agent: Self = >nsubj|<xcomp >nsubj
+      location: Location? = >/${preps}/|
+               >/advmod/
+
+  - name: "Help_command"
+    label: HelpCommand
+    example: "You should help him."
     priority: ${ rulepriority }
     pattern: |
-      trigger = [lemma=/assist|help|aid|support/] [!mention=HelpOffer]
-      agent: Self = >nsubj|<xcomp >nsubj
+      trigger = [lemma=/assist|help|aid|support/]
+      agent: Entity = >nsubj [!mention=Self] |<xcomp >nsubj [!mention=Self]
+      helpee: Entity = >ccomp >nsubj | >ccomp | >dep | >dobj
+      location: Location? = >/${preps}/|
+               >/advmod/
+
+  - name: "Help_command_no_agent"
+    label: HelpCommand
+    example: "You should help him. Help me!"
+    priority: ${ second_priority }
+    pattern: |
+      trigger = [lemma=/assist|help|aid|support/ & !mention=HelpRequest & !mention=HelpOffer]
+      #agent: Entity = >nsubj [!mention=Self] |<xcomp >nsubj [!mention=Self]
+      helpee: Entity = >ccomp >nsubj | >ccomp | >dep | >dobj
       location: Location? = >/${preps}/|
                >/advmod/

--- a/src/main/resources/org/clulab/asist/grammars/team_communication.yml
+++ b/src/main/resources/org/clulab/asist/grammars/team_communication.yml
@@ -403,7 +403,7 @@ rules:
     pattern: |
       trigger = [lemma=/assist|help|aid|support/]
       agent: Entity = >nsubj [!mention=Self] |<xcomp >nsubj [!mention=Self]
-      helpee: Entity = >ccomp >nsubj | >ccomp | >dep | >dobj
+      helpee: Entity = >ccomp >nsubj [!mention=You] | >ccomp [!mention=You] | >dep [!mention=You] | >dobj [!mention=You]
       location: Location? = >/${preps}/|
                >/advmod/
 
@@ -413,7 +413,6 @@ rules:
     priority: ${ second_priority }
     pattern: |
       trigger = [lemma=/assist|help|aid|support/ & !mention=HelpRequest & !mention=HelpOffer]
-      #agent: Entity = >nsubj [!mention=Self] |<xcomp >nsubj [!mention=Self]
-      helpee: Entity = >ccomp >nsubj | >ccomp | >dep | >dobj
+      helpee: Entity = >ccomp >nsubj [!mention=You] | >ccomp [!mention=You] | >dep [!mention=You] | >dobj [!mention=You]
       location: Location? = >/${preps}/|
                >/advmod/

--- a/src/test/scala/org/clulab/asist/rules/TestCommunications.scala
+++ b/src/test/scala/org/clulab/asist/rules/TestCommunications.scala
@@ -101,11 +101,12 @@ class TestCommunications extends BaseTest {
 
   }
 
-  passingTest should "parse instructions" in {
+  passingTest should "parse help command" in {
     val text = "Come help me here!"
     val mentions = extractor.extractFrom(text)
-    val action = DesiredMention("GenericAction", "help")
-    val inst = DesiredMention("Instruction", "Come help", Map("topic" -> Seq(action)))
+    val helpee = DesiredMention("Self", "me")
+    val location = DesiredMention("Deictic", "here")
+    val inst = DesiredMention("HelpCommand", "help me here", Map("helpee" -> Seq(helpee), "location" ->Seq(location)))
 
     testMention(mentions, inst)
   }
@@ -150,6 +151,14 @@ class TestCommunications extends BaseTest {
     testMention(mentions, toolBroken)
   }
 
+  passingTest should "parse help offers" in {
+    val text = "I can help you."
+    val mentions = extractor.extractFrom(text)
+    val you = DesiredMention("You","you")
+    val save = DesiredMention("HelpOffer", "help you", Map("helpee" -> Seq(you)),Set(AGENT_SELF))
+
+    testMention(mentions,save)
+  }
 
 
 


### PR DESCRIPTION
This PR takes care of some modelling team requests surrounding Team Communication.

New Labels:

> 1. **HelpOffer**
> > This is for players offering help to others. It is a subset of the Communicate label. Examples: "I can help you", "Let me help"

> 2. **HelpCommand**
>> This is for players asking or instructing other players to help others or themselves. It is a subset of the Instruction label. Examples: "You should help the engineer.", "Help me!"

Other updates:

- HelpRequest has been expanded for better coverage
- Unit tests added for HelpCommand and HelpOffer labels