### PR TITLE
Trial message handling

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -29,7 +29,7 @@ DialogAgent {
   // Directory containing .metadata files to reprocess
   inputDir = ""
 
-  // Directory to write the reprocessed .metadata files to
+  // Reprocessor output directory
   outputDir = "reprocessed_output"
 
   // URL for the Texas A&M University Dialogue Act Classifier service
@@ -90,7 +90,6 @@ Trial {
   msg {
     sub_type{
       trial_start = "start"
-      trial_stop = "stop"
     }
   }
 }

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -35,9 +35,6 @@ class DialogAgentMqtt(
   // enqueue messages from the bus if they're coming in too fast.
   private val queue: Queue[BusMessage] = new Queue 
 
-  // Testbed heartbeat
-  private val heartbeatProducer = new HeartbeatProducer(this)
-
   private val source_type = "message_bus"
 
   // communication with Message Bus
@@ -56,6 +53,9 @@ class DialogAgentMqtt(
     ),
     this
   )
+
+  // Testbed heartbeat (this will start immediately)
+  private val heartbeatProducer = new HeartbeatProducer(this)
 
   /** Publish a list of bus messages
    * @param output A list of objects to be published to the Message Bus
@@ -128,12 +128,8 @@ class DialogAgentMqtt(
           topicPubVersionInfo,
           outputJson
         )
-        heartbeatProducer.start(trial)
+        heartbeatProducer.set_trial_info(trial)
         writeOutput(List(output))
-        doNextJob
-      }
-      else if(TrialMessage.isStop(trial)) { // Trial Stop
-        heartbeatProducer.stop
         doNextJob
       }
     case _ => 

--- a/src/main/scala/org/clulab/asist/agents/HeartbeatProducer.scala
+++ b/src/main/scala/org/clulab/asist/agents/HeartbeatProducer.scala
@@ -49,6 +49,7 @@ class HeartbeatProducer(agent: DialogAgentMqtt) extends LazyLogging {
    */
   def set_trial_info(trial: TrialMessage): Unit = {
     base = HeartbeatMessage(trial)
+    beat
   }
 
   // publish the heartbeat message 

--- a/src/main/scala/org/clulab/asist/messages/Common.scala
+++ b/src/main/scala/org/clulab/asist/messages/Common.scala
@@ -5,9 +5,8 @@ package org.clulab.asist.messages
  *
  *  Components used for subscription and publication on the Message Bus
  *
- *  Optional fields are omitted from output if value is not known
- *
- *  Fields required by the Testbed have "not_set" values by default
+ *  Fields required by the Testbed to be included with published JSON 
+ *  have "not_set" values by default
  *
  *  Optional fields have "N/A" values, used in place of "null".  
  *  The DialogAgent will not publish a field with this value
@@ -18,7 +17,8 @@ case class Topic(
 )
 
 // Testbed specification:
-// https://gitlab.asist.aptima.com/asist/testbed/-/blob/master/MessageSpecs/Common_Header/common_header.json
+// https://gitlab.asist.aptima.com/asist\
+// /testbed/-/blob/master/MessageSpecs/Common_Header/common_header.json
 case class CommonHeader(
   timestamp: String = "not_set",
   message_type: String = "not_set", 
@@ -26,7 +26,8 @@ case class CommonHeader(
 )
 
 // Testbed specification:
-// https://gitlab.asist.aptima.com/asist/testbed/-/blob/master/MessageSpecs/Common_Message/common_message.json
+// https://gitlab.asist.aptima.com/asist\
+// /testbed/-/blob/master/MessageSpecs/Common_Message/common_message.json
 case class CommonMsg (
   experiment_id: String = "not_set",
   trial_id: String = "N/A",

--- a/src/main/scala/org/clulab/asist/messages/HeartbeatMessage.scala
+++ b/src/main/scala/org/clulab/asist/messages/HeartbeatMessage.scala
@@ -47,6 +47,11 @@ object HeartbeatMessage {
     status = config.getString("Heartbeat.data.status")
   )
 
+  /** Build from nothing 
+   *  @return A new HeartbeatMessage based on default values
+   */
+  def apply(): HeartbeatMessage = HeartbeatMessage(header, msg, data)
+
   /** Build from a trial message
    *  @param trial A trial message
    *  @return A new HeartbeatMessage based on the trial message

--- a/src/main/scala/org/clulab/asist/messages/HeartbeatMessage.scala
+++ b/src/main/scala/org/clulab/asist/messages/HeartbeatMessage.scala
@@ -7,9 +7,10 @@ import ai.lum.common.ConfigFactory
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal
  *
- *  Heartbeat Message based on:
- *
- *  https://gitlab.asist.aptima.com/asist/testbed/-/blob/develop/AsistDataIngesterContainer/src/AsistDataIngester/Models/HeartbeatMessage.cs
+ *  Testbed specification:
+ *  https://gitlab.asist.aptima.com/asist\
+ *  /testbed/-/blob/develop/AsistDataIngesterContainer/src\
+ *  /AsistDataIngester/Models/HeartbeatMessage.cs
  *
  */
 

--- a/src/main/scala/org/clulab/asist/messages/TrialMessage.scala
+++ b/src/main/scala/org/clulab/asist/messages/TrialMessage.scala
@@ -23,8 +23,6 @@ object TrialMessage {
   // state flags
   private val trial_start: String = 
     config.getString("Trial.msg.sub_type.trial_start")
-  private val trial_stop: String = 
-    config.getString("Trial.msg.sub_type.trial_stop")
  
   // subscription filter
   private val header_message_type: String = 
@@ -43,13 +41,6 @@ object TrialMessage {
    */
   def isStart(trial: TrialMessage): Boolean = 
     (trial.msg.sub_type == trial_start)
-
-  /* test for trial stop
-   * @param trial A Trial message that may or may not be a trial stop
-   * @return true if the message is a Trial Stop
-   */
-  def isStop(trial: TrialMessage): Boolean = 
-    (trial.msg.sub_type == trial_stop)
 
   /* only messages meeting these criteria are processed
    * @param trial A Chat message that may or may not meet the criteria

--- a/src/main/scala/org/clulab/asist/messages/VersionInfo.scala
+++ b/src/main/scala/org/clulab/asist/messages/VersionInfo.scala
@@ -96,11 +96,6 @@ object VersionInfo
         config.getString("Trial.msg.sub_type.trial_start")
       ),
       VersionInfoDataMessageChannel(
-        config.getString("Trial.topic"),
-        config.getString("Trial.header.message_type"),
-        config.getString("Trial.msg.sub_type.trial_stop")
-      ),
-      VersionInfoDataMessageChannel(
         config.getString("Asr.topic"),
         config.getString("Asr.header.message_type"),
         config.getString("Asr.msg.sub_type")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.1.3"
+version in ThisBuild := "4.1.4"


### PR DESCRIPTION
- 'trial stop' entry removed from config file and dependent classes
- 'trial start' message now immediately sends the updated heartbeat message 
 