### PR TITLE
Makefile fix joseph

### DIFF
--- a/scripts/mqtt_agent_testing/Makefile
+++ b/scripts/mqtt_agent_testing/Makefile
@@ -8,10 +8,13 @@ test: FORCE
 
 # A complete tour of every subscribed topic tested
 test_everything: FORCE
+	make test_trial_start -s
 	make test_asr -s
 	make test_chat -s
-	make test_trial_start -s
 	make test_trial_stop -s
+
+test_trial_start: FORCE
+	cd trial_start; make test -s
 
 test_asr: FORCE
 	cd asr; make test -s
@@ -19,18 +22,15 @@ test_asr: FORCE
 test_chat: FORCE
 	cd chat; make test -s
 
-test_trial_start: FORCE
-	cd trial_start; make test -s
-
 test_trial_stop: FORCE
 	cd trial_stop; make test -s
 
 
 # remove intermediate test result files
 clean: FORCE
+	cd trial_start; make clean -s
 	cd asr; make clean -s
 	cd chat; make clean -s
-	cd trial_start; make clean -s
 	cd trial_stop; make clean -s
 
 show_received_files: FORCE

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.1.4"
+version in ThisBuild := "4.1.5"


### PR DESCRIPTION
- Test groups now begin with trial start and finish with trial stop
- Groups are repeated to simulate multiple trials.
- I set the version to 4.1.5 to freeze the 4.1.4 version at the Testbed release