### PR TITLE
scopt argument parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ libraryDependencies ++= {
     "com.google.code.gson" % "gson" % "2.8.5",
     "io.spray" %%  "spray-json" % "1.3.5",
     "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.2.5",
+    "com.github.scopt" %% "scopt" % "4.0.1"
   )
 }
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentReprocessor.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentReprocessor.scala
@@ -8,7 +8,6 @@ import org.clulab.asist.messages._
 import org.clulab.utils.LocalFileUtils
 import org.json4s.{Extraction,_}
 
-import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import scala.io.Source
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
@@ -13,13 +13,12 @@ import java.util.Scanner
 
 class DialogAgentStdin extends DialogAgent { 
 
-  println(s"\nRunning Dialog Agent stdin extractor version ${BuildInfo.version}")
-  println("Enter plaintext for extraction, [CTRL-D] to exit.")
-
-  print("\n> ")
-
   // get rule engine lazy init out of the way
   startEngine()
+
+  println(s"\nRunning Dialog Agent stdin extractor version ${BuildInfo.version}")
+  println("Enter plaintext for extraction, [CTRL-D] to exit.")
+  print("\n> ")
 
   // Console input
   val input = new Scanner(System.in)

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -26,11 +26,6 @@ import java.io.File
 
 object RunDialogAgent extends App {
 
-  case class Mqtt(
-    host: String, 
-    port: String
-  )
-
   object RunMode extends Enumeration {
     type RunMode = Value
     val MQTT, FILE, REPROCESS, STDIN, NONE = Value
@@ -39,14 +34,14 @@ object RunDialogAgent extends App {
   import RunMode._
 
   case class Arguments(
-    mqtt: Option[Mqtt] = None,
-    host: Option[String] = None,
-    port: Option[String] = None,
     // optional flag to exclude Minecraft Chat messages from File or Mqtt input
     nochat: Boolean = false,
 
     // which Dialog Agent variant to run
-    runMode: RunMode = RunMode.NONE
+    runMode: RunMode = RunMode.NONE,
+
+    // Dialog Agent variants and their args
+    kwargs: Map[String, String] = Map()
   )
 
   val parser = new scopt.OptionParser[Arguments]("Parsing application") {
@@ -58,16 +53,13 @@ object RunDialogAgent extends App {
       .text("nochat is a flag")
 
     opt[String]("mqtt")
-      .action((h, p, c) => 
-        c.copy(
-          host = Some(h),
-          port = Some(p),
-          runMode = MQTT
-        )
-      )
+      .action((_, c) =>c.copy(runMode = MQTT))
       .text("mqtt host is a thing")
 
-
+    opt[Map[String, String]]("kwargs")
+      .valueName("k1=v1,k2=v2...")
+      .action((x, c) => c.copy(kwargs = x))
+      .text("other arguments"),
   }
 
   def run(arguments: Arguments): Unit = {

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -37,7 +37,10 @@ object RunDialogAgent extends App {
     src: String = "",
 
     // output location for file and reprocessor agents
-    dst: String = ""
+    dst: String = "",
+
+    // experimental mqtt type with map arg
+    mqtt: Option[Map[String, String]] = None
   )
 
   val parser = new scopt.OptionParser[Arguments]("Parsing application") {
@@ -61,18 +64,24 @@ object RunDialogAgent extends App {
       .text("Message Bus host machine port (mqtt agent)")
 
     opt[String]("src")
-      .valueName("<filename or directory>")
+      .valueName("<file or dir>")
       .action((x, c) =>c.copy(src = x))
       .text("input location (file and reprocessor agents)")
 
     opt[String]("dst")
-      .valueName("<directory>")
+      .valueName("<dir>")
       .action((x, c) =>c.copy(dst = x))
       .text("output location (file and reprocessor agents)")
 
     opt[Unit]("nochat")
+      .valueName("flag")
       .action((_, c) => c.copy(nochat = true))
       .text("Optional flag to exclude Minecraft Chat messages (mqtt and file agents)")
+
+    opt[Map[String, String]]("mqtt")
+      .valueName("args")
+      .action((x, c) => c.copy(mqtt = Some(x)))
+      .text("MQTT agent with kwargs")
   }
 
   def run(arguments: Arguments): Unit = arguments.agent.toLowerCase match {
@@ -98,7 +107,11 @@ object RunDialogAgent extends App {
   }
 
   parser.parse(args, Arguments()) match {
-    case Some(arguments) => run(arguments)
+    case Some(arguments) => 
+      run(arguments)
+      arguments.mqtt.foreach(mqtt =>
+          println("MQTT: ")
+      )
     case _ =>  // usage will be shown
   }
 }

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -26,22 +26,23 @@ import java.io.File
 
 object RunDialogAgent extends App {
 
-    case class Arguments(inputDir: String = "",
-                         outputDir: String = "")
+    case class Arguments(
+      nochat: Boolean = false
+    )
 
     val parser = new scopt.OptionParser[Arguments]("Parsing application") {
 
-        opt[String]('i', "inputDir").
-            required().valueName("").action((value, arguments) => arguments.copy(inputDir = value))
+        head("scopt", "4.0.1")
 
-        opt[String]('o', "outputDir").
-            required().valueName("").action((value, arguments) => arguments.copy(outputDir = value))
+        opt[Unit]("nochat")
+          .action((_, c) => c.copy(nochat = true))
+          .text("nochat is a flag"),
+
 
     }
 
     def run(arguments: Arguments): Unit = {
-        println("Input Dir:" + arguments.inputDir)
-        println("Output Dir:" + arguments.outputDir)
+        println("nochat boolean:" + arguments.nochat)
     }
 
     parser.parse(args, Arguments()) match {

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -2,8 +2,12 @@ package org.clulab.asist.apps
 
 import com.typesafe.scalalogging.LazyLogging
 import org.clulab.asist.agents._
+import scopt.OParser
 
 import scala.annotation.tailrec
+import java.io.File
+
+
 
 
 /**
@@ -21,6 +25,30 @@ import scala.annotation.tailrec
  */
 
 object RunDialogAgent extends App {
+
+    case class Arguments(inputDir: String = "",
+                         outputDir: String = "")
+
+    val parser = new scopt.OptionParser[Arguments]("Parsing application") {
+
+        opt[String]('i', "inputDir").
+            required().valueName("").action((value, arguments) => arguments.copy(inputDir = value))
+
+        opt[String]('o', "outputDir").
+            required().valueName("").action((value, arguments) => arguments.copy(outputDir = value))
+
+    }
+
+    def run(arguments: Arguments): Unit = {
+        println("Input Dir:" + arguments.inputDir)
+        println("Output Dir:" + arguments.outputDir)
+    }
+
+    parser.parse(args, Arguments()) match {
+        case Some(arguments) => run(arguments)
+        case None =>
+    }
+
   
   // splash page if args are not understood
   val usageText = List(

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -26,7 +26,13 @@ import java.io.File
 
 object RunDialogAgent extends App {
 
+    case class Mqtt(
+      host: String, 
+      port: String
+    )
+
     case class Arguments(
+      mqtt: Option[Mqtt] = None,
       nochat: Boolean = false
     )
 
@@ -42,7 +48,7 @@ object RunDialogAgent extends App {
     }
 
     def run(arguments: Arguments): Unit = {
-        println("nochat boolean:" + arguments.nochat)
+        println("nochat boolean: " + arguments.nochat)
     }
 
     parser.parse(args, Arguments()) match {

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -3,10 +3,9 @@ package org.clulab.asist.apps
 import com.typesafe.scalalogging.LazyLogging
 import org.clulab.asist.agents._
 import scopt.OParser
+import buildinfo.BuildInfo
 
-import scala.annotation.tailrec
 import java.io.File
-
 
 
 
@@ -21,7 +20,7 @@ import java.io.File
 object RunDialogAgent extends App {
 
   case class Arguments(
-    // optional flag to exclude Minecraft Chat messages from File or Mqtt input
+    // optional flag to exclude Chat messages from File or Mqtt input
     nochat: Boolean = false,
 
     // which Dialog Agent variant to run
@@ -41,41 +40,56 @@ object RunDialogAgent extends App {
   )
 
   val parser = new scopt.OptionParser[Arguments]("Parsing application") {
-
-    head("scopt", "4.0.1")
-
-    arg[String]("agent")
-      .required()
-      .valueName("<type>")
-      .action((x, c) =>c.copy(agent = x))
-      .text("One of [mqtt, reprocess, stdin, file]")
-
-    opt[String]("host")
-      .valueName("<name>")
-      .action((x, c) =>c.copy(host = x))
-      .text("Message Bus host machine name (mqtt agent)")
-
-    opt[String]("port")
-      .valueName("<number>")
-      .action((x, c) =>c.copy(port = x))
-      .text("Message Bus host machine port (mqtt agent)")
-
-    opt[String]("src")
-      .valueName("<file or dir>")
-      .action((x, c) =>c.copy(src = x))
-      .text("input location (file and reprocessor agents)")
-
-    opt[String]("dst")
-      .valueName("<dir>")
-      .action((x, c) =>c.copy(dst = x))
-      .text("output location (file and reprocessor agents)")
-
-    opt[Unit]("nochat")
-      .action((_, c) => c.copy(nochat = true))
-      .text("Optional flag to exclude Minecraft Chat messages (mqtt and file agents)")
+    head("University of Arizona Dialog Agent", BuildInfo.version)
+    help("help").text("prints usage text")
+    version("version").text("prints header text")
+    cmd("mqtt")
+      .action((_, c) =>c.copy(agent = "mqtt"))
+      .children(
+        arg[String]("host")
+          .valueName("<String>")
+          .action((x, c) =>c.copy(host = x))
+          .text("Message Bus host machine name"),
+        arg[String]("port")
+          .valueName("<String>")
+          .action((x, c) =>c.copy(port = x))
+          .text("Message Bus host port name"),
+        opt[Unit]("nochat")
+          .action((_, c) => c.copy(nochat = true))
+          .text("Optional flag to exclude Minecraft Chat messages")
+        )
+    cmd("file")
+      .action((_, c) =>c.copy(agent = "file"))
+      .children(
+        arg[String]("src")
+          .valueName("<String>")
+          .action((x, c) =>c.copy(src = x))
+          .text("input (directory or file)"),
+        arg[String]("dst")
+          .valueName("<String>")
+          .action((x, c) =>c.copy(dst = x))
+          .text("output directory"),
+        opt[Unit]("nochat")
+          .action((_, c) => c.copy(nochat = true))
+          .text("Optional flag to exclude Minecraft Chat messages")
+        )
+    cmd("stdin")
+      .action((_, c) =>c.copy(agent = "stdin"))
+    cmd("reprocess")
+      .action((_, c) =>c.copy(agent = "reprocess"))
+      .children(
+        arg[String]("src")
+          .valueName("<String>")
+          .action((x, c) =>c.copy(src = x))
+          .text("input directory"),
+        arg[String]("dst")
+          .valueName("<String>")
+          .action((x, c) =>c.copy(dst = x))
+          .text("output directory"),
+        )
   }
 
-  def run(arguments: Arguments): Unit = arguments.agent.toLowerCase match {
+  def run(arguments: Arguments): Unit = arguments.agent match {
     case "mqtt" =>
       println("MQTT agent:")
       println("host:  " + arguments.host) 
@@ -93,7 +107,8 @@ object RunDialogAgent extends App {
     case "stdin" =>
       println("Stdin agent:")
     case _ =>
-      println(f"Could not run agent '${arguments.agent}', valid agent types are [mqtt, reprocess, stdin, file]")
+      println(f"Could not run agent '${arguments.agent}'")
+      println("valid agent types are [mqtt, reprocess, stdin, file]")
 
   }
 

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -26,35 +26,63 @@ import java.io.File
 
 object RunDialogAgent extends App {
 
-    case class Mqtt(
-      host: String, 
-      port: String
-    )
+  case class Mqtt(
+    host: String, 
+    port: String
+  )
 
-    case class Arguments(
-      mqtt: Option[Mqtt] = None,
-      nochat: Boolean = false
-    )
+  object RunMode extends Enumeration {
+    type RunMode = Value
+    val MQTT, FILE, REPROCESS, STDIN, NONE = Value
+  }
 
-    val parser = new scopt.OptionParser[Arguments]("Parsing application") {
+  import RunMode._
 
-        head("scopt", "4.0.1")
+  case class Arguments(
+    mqtt: Option[Mqtt] = None,
+    host: Option[String] = None,
+    port: Option[String] = None,
+    // optional flag to exclude Minecraft Chat messages from File or Mqtt input
+    nochat: Boolean = false,
 
-        opt[Unit]("nochat")
-          .action((_, c) => c.copy(nochat = true))
-          .text("nochat is a flag"),
+    // which Dialog Agent variant to run
+    runMode: RunMode = RunMode.NONE
+  )
+
+  val parser = new scopt.OptionParser[Arguments]("Parsing application") {
+
+    head("scopt", "4.0.1")
+
+    opt[Unit]("nochat")
+      .action((_, c) => c.copy(nochat = true))
+      .text("nochat is a flag")
+
+    opt[String]("mqtt")
+      .action((h, p, c) => 
+        c.copy(
+          host = Some(h),
+          port = Some(p),
+          runMode = MQTT
+        )
+      )
+      .text("mqtt host is a thing")
 
 
-    }
+  }
 
-    def run(arguments: Arguments): Unit = {
-        println("nochat boolean: " + arguments.nochat)
-    }
+  def run(arguments: Arguments): Unit = {
+    println("nochat: " + arguments.nochat)
+    println("runMode:  " + arguments.runMode.toString) 
+  }
 
-    parser.parse(args, Arguments()) match {
-        case Some(arguments) => run(arguments)
-        case None =>
-    }
+  parser.parse(args, Arguments()) match {
+    case Some(arguments) => run(arguments)
+    case _ =>  // usage will be shown
+  }
+}
+
+
+class Foo{
 
   
   // splash page if args are not understood
@@ -82,6 +110,7 @@ object RunDialogAgent extends App {
    * @param argList A flat list of keys and values
    * @return The value if the key is found, else None
    */
+  /*
   @tailrec
   def ta3Version(arglist: List[String]): Option[Int] = arglist match {
     case "-v"::version::l =>
@@ -93,22 +122,26 @@ object RunDialogAgent extends App {
       ta3Version(l)
     case _ => None
   }
+  */
 
   /** Check if the 'nochat' flag is set
    * @param argList A flat list of keys and values
    * @return true if the key is found
    */
+  /*
   @tailrec
   def nochat(arglist: List[String]): Boolean = arglist match {
     case "--nochat"::l => true
     case head::l => nochat(l)
     case _ => false
   }
+  */
 
   /** Create a Dialog Agent per user args.
    * @param argList A flat list of running mode then n key-value pairs
    * @return A DialogAgent running in the mode with the args
    */
+  /*
   args.toList match {
     case ("mqtt"::host::port::l) => 
       new DialogAgentMqtt(host, port, nochat(l))
@@ -119,6 +152,8 @@ object RunDialogAgent extends App {
     case ("reprocess"::indir::outdir::l) =>
       new DialogAgentReprocessor(indir, outdir, ta3Version(l))
     case _ =>
+
       usageText.foreach(println)
   }
+  */
 }

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -38,16 +38,13 @@ object RunDialogAgent extends App {
 
     // output location for file and reprocessor agents
     dst: String = "",
-
-    // experimental mqtt type with map arg
-    mqtt: Option[Map[String, String]] = None
   )
 
   val parser = new scopt.OptionParser[Arguments]("Parsing application") {
 
     head("scopt", "4.0.1")
 
-    opt[String]("agent")
+    arg[String]("agent")
       .required()
       .valueName("<type>")
       .action((x, c) =>c.copy(agent = x))
@@ -74,14 +71,8 @@ object RunDialogAgent extends App {
       .text("output location (file and reprocessor agents)")
 
     opt[Unit]("nochat")
-      .valueName("flag")
       .action((_, c) => c.copy(nochat = true))
       .text("Optional flag to exclude Minecraft Chat messages (mqtt and file agents)")
-
-    opt[Map[String, String]]("mqtt")
-      .valueName("args")
-      .action((x, c) => c.copy(mqtt = Some(x)))
-      .text("MQTT agent with kwargs")
   }
 
   def run(arguments: Arguments): Unit = arguments.agent.toLowerCase match {
@@ -109,86 +100,7 @@ object RunDialogAgent extends App {
   parser.parse(args, Arguments()) match {
     case Some(arguments) => 
       run(arguments)
-      arguments.mqtt.foreach(mqtt =>
-          println("MQTT: ")
-      )
     case _ =>  // usage will be shown
   }
 }
 
-
-class Foo{
-
-  
-  // splash page if args are not understood
-  val usageText = List(
-    "",
-    "usage:",
-    "",
-    "  mqtt <host> <port> [--nochat]",
-    "  stdin",
-    "  file <inputfile> <outputfile> [--nochat]",
-    "  reprocess <inputdir> <outputdir> [-v ta3_version_number]}",
-    "",
-    "-v         : Set the TA3 version number of reprocessed metadata files.",
-    "             If not set, existing TA3 version numbers are incremented by 1",
-    "--nochat   : Exclude Minecraft Chat messages from processing",
-    "inputfile  : supported file extensions are .vtt and .metadata",
-    "              (also handles directories containing files with those extensions)",
-    "outputfile : Processed file input will be written here.",
-    "inputdir   : A directory of .metadata files to be reprocessed by the DialogAgent",
-    "outputdir  : A directory where reprocessed .metadata files will be saved.",
-    ""
-  )
-
-  /** Find the TA3 Version number arg in the arg list
-   * @param argList A flat list of keys and values
-   * @return The value if the key is found, else None
-   */
-  /*
-  @tailrec
-  def ta3Version(arglist: List[String]): Option[Int] = arglist match {
-    case "-v"::version::l =>
-      try Some(version.toInt)
-      catch {
-        case e: Exception => None
-      }
-    case head::l =>
-      ta3Version(l)
-    case _ => None
-  }
-  */
-
-  /** Check if the 'nochat' flag is set
-   * @param argList A flat list of keys and values
-   * @return true if the key is found
-   */
-  /*
-  @tailrec
-  def nochat(arglist: List[String]): Boolean = arglist match {
-    case "--nochat"::l => true
-    case head::l => nochat(l)
-    case _ => false
-  }
-  */
-
-  /** Create a Dialog Agent per user args.
-   * @param argList A flat list of running mode then n key-value pairs
-   * @return A DialogAgent running in the mode with the args
-   */
-  /*
-  args.toList match {
-    case ("mqtt"::host::port::l) => 
-      new DialogAgentMqtt(host, port, nochat(l))
-    case ("file"::infile::outfile::l) =>
-      new DialogAgentFile(infile, outfile, nochat(l))
-    case ("stdin"::l) =>
-      new DialogAgentStdin
-    case ("reprocess"::indir::outdir::l) =>
-      new DialogAgentReprocessor(indir, outdir, ta3Version(l))
-    case _ =>
-
-      usageText.foreach(println)
-  }
-  */
-}

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -26,22 +26,19 @@ import java.io.File
 
 object RunDialogAgent extends App {
 
-  object RunMode extends Enumeration {
-    type RunMode = Value
-    val MQTT, FILE, REPROCESS, STDIN, NONE = Value
-  }
-
-  import RunMode._
-
   case class Arguments(
     // optional flag to exclude Minecraft Chat messages from File or Mqtt input
     nochat: Boolean = false,
 
     // which Dialog Agent variant to run
-    runMode: RunMode = RunMode.NONE,
+    agent: String = "",
 
-    // Dialog Agent variants and their args
-    kwargs: Map[String, String] = Map()
+    // Mosquitto broker host for mqtt runmode
+    host: String = "",
+
+    // Mosquitto broker port for mqtt runmode
+    port: String = "",
+
   )
 
   val parser = new scopt.OptionParser[Arguments]("Parsing application") {
@@ -50,21 +47,40 @@ object RunDialogAgent extends App {
 
     opt[Unit]("nochat")
       .action((_, c) => c.copy(nochat = true))
-      .text("nochat is a flag")
+      .text("Optional flag to exclude Minecraft Chat messages from mqtt and file runmodes")
 
-    opt[String]("mqtt")
-      .action((_, c) =>c.copy(runMode = MQTT))
-      .text("mqtt host is a thing")
+    opt[String]("agent")
+      .required()
+      .valueName("<type>")
+      .action((x, c) =>c.copy(agent = x))
+      .text("One of [mqtt, reprocess, stdin, file]")
 
-    opt[Map[String, String]]("kwargs")
-      .valueName("k1=v1,k2=v2...")
-      .action((x, c) => c.copy(kwargs = x))
-      .text("other arguments"),
+    opt[String]("host")
+      .valueName("<name>")
+      .action((x, c) =>c.copy(host = x))
+      .text("Message Bus host machine name")
+
+    opt[String]("port")
+      .valueName("<number>")
+      .action((x, c) =>c.copy(port = x))
+      .text("Message Bus host machine port")
   }
 
-  def run(arguments: Arguments): Unit = {
-    println("nochat: " + arguments.nochat)
-    println("runMode:  " + arguments.runMode.toString) 
+  def run(arguments: Arguments): Unit = arguments.agent.toLowerCase match {
+    case "mqtt" =>
+      println("MQTT agent:")
+      println("host:  " + arguments.host) 
+      println("port:  " + arguments.port) 
+      if(arguments.nochat) println("Minecraft Chat messages not processed")
+    case "file" =>
+      println("File agent:")
+    case "reprocess" =>
+      println("Reprocess agent:")
+    case "stdin" =>
+      println("Stdin agent:")
+    case _ =>
+      println(f"Could not run agent '${arguments.agent}', valid agent types are [mqtt, reprocess, stdin, file]")
+
   }
 
   parser.parse(args, Arguments()) match {

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -13,15 +13,9 @@ import java.io.File
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
  *
- *  Updated:  2021 June
+ *  This application will run the DialogAgent on the Message Bus, 
+ *  file input, or interactively.
  *
- *  This application will run the DialogAgent on an input file, on the
- *  message bus, or interactively depending on user inputs.
- *
- *  The arguments are expected as an Array of string vaue with the element
- *  at index 0 being the run mode, and the remainder as key-value pairs:  
- *  
- *    Array("mode","key1","value1","key2","value2", ...)
  */
 
 object RunDialogAgent extends App {
@@ -33,21 +27,22 @@ object RunDialogAgent extends App {
     // which Dialog Agent variant to run
     agent: String = "",
 
-    // Mosquitto broker host for mqtt runmode
+    // Mosquitto broker host for mqtt agent
     host: String = "",
 
-    // Mosquitto broker port for mqtt runmode
+    // Mosquitto broker port for mqtt agent
     port: String = "",
 
+    // input location for file and reprocessor agents
+    src: String = "",
+
+    // output location for file and reprocessor agents
+    dst: String = ""
   )
 
   val parser = new scopt.OptionParser[Arguments]("Parsing application") {
 
     head("scopt", "4.0.1")
-
-    opt[Unit]("nochat")
-      .action((_, c) => c.copy(nochat = true))
-      .text("Optional flag to exclude Minecraft Chat messages from mqtt and file runmodes")
 
     opt[String]("agent")
       .required()
@@ -58,12 +53,26 @@ object RunDialogAgent extends App {
     opt[String]("host")
       .valueName("<name>")
       .action((x, c) =>c.copy(host = x))
-      .text("Message Bus host machine name")
+      .text("Message Bus host machine name (mqtt agent)")
 
     opt[String]("port")
       .valueName("<number>")
       .action((x, c) =>c.copy(port = x))
-      .text("Message Bus host machine port")
+      .text("Message Bus host machine port (mqtt agent)")
+
+    opt[String]("src")
+      .valueName("<filename or directory>")
+      .action((x, c) =>c.copy(src = x))
+      .text("input location (file and reprocessor agents)")
+
+    opt[String]("dst")
+      .valueName("<directory>")
+      .action((x, c) =>c.copy(dst = x))
+      .text("output location (file and reprocessor agents)")
+
+    opt[Unit]("nochat")
+      .action((_, c) => c.copy(nochat = true))
+      .text("Optional flag to exclude Minecraft Chat messages (mqtt and file agents)")
   }
 
   def run(arguments: Arguments): Unit = arguments.agent.toLowerCase match {
@@ -74,8 +83,13 @@ object RunDialogAgent extends App {
       if(arguments.nochat) println("Minecraft Chat messages not processed")
     case "file" =>
       println("File agent:")
+      println("src:  " + arguments.src) 
+      println("dst:  " + arguments.dst) 
+      if(arguments.nochat) println("Minecraft Chat messages not processed")
     case "reprocess" =>
       println("Reprocess agent:")
+      println("src:  " + arguments.src) 
+      println("dst:  " + arguments.dst) 
     case "stdin" =>
       println("Stdin agent:")
     case _ =>

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -7,8 +7,6 @@ import buildinfo.BuildInfo
 
 import java.io.File
 
-
-
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
  *
@@ -17,7 +15,7 @@ import java.io.File
  *
  */
 
-object RunDialogAgent extends App {
+object RunDialogAgent extends App with LazyLogging {
 
   case class Arguments(
     // optional flag to exclude Chat messages from File or Mqtt input
@@ -37,8 +35,14 @@ object RunDialogAgent extends App {
 
     // output location for file and reprocessor agents
     dst: String = "",
+
+    // Optional TA3 file version for reprocessor
+    ta3_version: Option[Int] = None
   )
 
+  val ta3_version_text: String = "Set the TA3 version number of reprocessed metadata files. If not set, existing TA3 version numbers are incremented by 1"
+
+  // set up the parser to use the Dialog Agent command line arguments
   val parser = new scopt.OptionParser[Arguments]("Parsing application") {
     head("University of Arizona Dialog Agent", BuildInfo.version)
     help("help").text("prints usage text")
@@ -64,11 +68,11 @@ object RunDialogAgent extends App {
         arg[String]("src")
           .valueName("<String>")
           .action((x, c) =>c.copy(src = x))
-          .text("input (directory or file)"),
+          .text("input file or directory"),
         arg[String]("dst")
           .valueName("<String>")
           .action((x, c) =>c.copy(dst = x))
-          .text("output directory"),
+          .text("output file"),
         opt[Unit]("nochat")
           .action((_, c) => c.copy(nochat = true))
           .text("Optional flag to exclude Minecraft Chat messages")
@@ -86,36 +90,51 @@ object RunDialogAgent extends App {
           .valueName("<String>")
           .action((x, c) =>c.copy(dst = x))
           .text("output directory"),
+        opt[Int]("v")
+          .action((x, c) => c.copy(ta3_version = Some(x)))
+          .text(ta3_version_text)
         )
   }
 
+  // Run the appropriate agent for the given arguments
   def run(arguments: Arguments): Unit = arguments.agent match {
     case "mqtt" =>
-      println("MQTT agent:")
-      println("host:  " + arguments.host) 
-      println("port:  " + arguments.port) 
-      if(arguments.nochat) println("Minecraft Chat messages not processed")
+      logger.info("Starting MQTT agent...")
+      logger.info("  host: " + arguments.host) 
+      logger.info("  port: " + arguments.port) 
+      if(arguments.nochat) logger.info("Minecraft Chat messages not processed")
+      new DialogAgentMqtt(arguments.host, arguments.port, arguments.nochat)
     case "file" =>
-      println("File agent:")
-      println("src:  " + arguments.src) 
-      println("dst:  " + arguments.dst) 
-      if(arguments.nochat) println("Minecraft Chat messages not processed")
+      logger.info("Starting File agent...")
+      logger.info("  input: " + arguments.src) 
+      logger.info("  output file: " + arguments.dst) 
+      if(arguments.nochat) logger.info("Minecraft Chat messages not processed")
+      new DialogAgentFile(arguments.src, arguments.dst, arguments.nochat)
     case "reprocess" =>
-      println("Reprocess agent:")
-      println("src:  " + arguments.src) 
-      println("dst:  " + arguments.dst) 
+      logger.info("Starting Reprocessor agent...")
+      logger.info("  input dir: " + arguments.src) 
+      logger.info("  output dir: " + arguments.dst) 
+      arguments.ta3_version.foreach(v => 
+        logger.info("  ta3 version: " + v)
+      )
+      new DialogAgentReprocessor(
+        arguments.src,
+        arguments.dst,
+        arguments.ta3_version
+      )
     case "stdin" =>
-      println("Stdin agent:")
+      logger.info("Starting Stdin agent...")
+      new DialogAgentStdin
     case _ =>
-      println(f"Could not run agent '${arguments.agent}'")
-      println("valid agent types are [mqtt, reprocess, stdin, file]")
-
+      logger.error(f"Could not run agent '${arguments.agent}'")
+      logger.error("valid agent types are [mqtt, reprocess, stdin, file]")
   }
 
+  // Run the arguments if parsing was successful
   parser.parse(args, Arguments()) match {
     case Some(arguments) => 
       run(arguments)
-    case _ =>  // usage will be shown
+    case _ =>  // usage will be shown otherwise
   }
 }
 


### PR DESCRIPTION
The Dialog Agents now use [scopt ](https://github.com/scopt/scopt) for argument parsing.   This required a slight change in that the optional TA3 version number argument used by the Reprocessor Agent is now preceded by two dashes.   Other than that the usage for all agents has not changed.