### PR TITLE
scopt command line argument processing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ libraryDependencies ++= {
     "com.google.code.gson" % "gson" % "2.8.5",
     "io.spray" %%  "spray-json" % "1.3.5",
     "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.2.5",
+    "com.github.scopt" %% "scopt" % "4.0.1"
   )
 }
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -19,8 +19,8 @@ import org.clulab.utils.{MessageBusClient, MessageBusClientListener}
  */
 
 class DialogAgentMqtt(
-  val host: String = "",
-  val port: String = "",
+  val host: String = "localhost",
+  val port: Int = 1883,
   val nochat: Boolean = false
 ) extends DialogAgent
     with LazyLogging

--- a/src/main/scala/org/clulab/utils/MessageBusClient.scala
+++ b/src/main/scala/org/clulab/utils/MessageBusClient.scala
@@ -22,15 +22,15 @@ trait MessageBusClientListener {
 }
 
 /** A client that manages publishing and subscribing to the Message Bus
- * @param host MQTT host to connect to.
- * @param port MQTT network port to connect to.
+ * @param host MQTT broker machine.
+ * @param port MQTT broker port.
  * @param subscriptions MQTT topics from which messages to process are read.
  * @param publications MQTT topic for publishing processed messages
  * @param listener A MessageBusClientListener that will process messages
  */
 class MessageBusClient(
-  val host: String = "",
-  val port: String = "",
+  val host: String = "localhost",
+  val port: Int = 1883,
   val subscriptions: List[String] = List.empty,
   val publications: List[String] = List.empty,
   val listener: MessageBusClientListener

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.1.6"
+version in ThisBuild := "5.0.0"


### PR DESCRIPTION
The scopt library is now used for command line processing.   The arguments for the MQTT agent are now optional (the default host is 'localhost' and the default port is 1883).   Version number is now 5.0.0 because these changes are not backwards compatible with previous scripts that ran the MQTT agent.