### PR TITLE
Version 5.1.1, Cleaned up exit logic on the Stdin Agent

### DIFF
--- a/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
@@ -1,6 +1,5 @@
 package org.clulab.asist.agents
 
-import scala.annotation.tailrec
 import buildinfo.BuildInfo
 import java.util.Scanner
 
@@ -24,22 +23,23 @@ class DialogAgentStdin extends DialogAgent {
   // Console input
   val input:Scanner = new Scanner(System.in)
 
-  readInput(0)
-  println("\nExiting program...")
+  var blankLines = 0
 
-  @tailrec
-  private def readInput(blankLines: Int): Unit = if(blankLines < 2) {
+  // scan input until user enters two consecutive blank lines
+  while(blankLines < 2) {
     print("\n> ")
     val text: String = input.nextLine
     if(text.isEmpty) {
-      readInput(blankLines + 1)
+      blankLines += 1
     }
     else {
       val extractions = engine.extractFrom(text, keepText = true)
       extractions.map(getExtraction).map(f => 
         println(JsonUtils.writeJson(f))
       )
-      readInput(0)
+      blankLines = 0
     }
   }
+
+  println("\nExiting program...")
 }

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
@@ -1,33 +1,45 @@
 package org.clulab.asist.agents
 
+import scala.annotation.tailrec
 import buildinfo.BuildInfo
 import java.util.Scanner
 
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
  *
- *  An interactive Dialog Agent that will return extractions for text entered
- *  on the command line
+ *  An interactive Dialog Agent that will return extractions for 
+ *  text entered on the command line
  *
  */
 
 class DialogAgentStdin extends DialogAgent { 
 
-  println(s"\nRunning Dialog Agent stdin extractor version ${BuildInfo.version}")
-  println("Enter plaintext for extraction, [CTRL-D] to exit.")
-
-  print("\n> ")
-
   // get rule engine lazy init out of the way
   startEngine()
 
-  // Console input
-  val input = new Scanner(System.in)
+  val v = BuildInfo.version
+  println(s"\nDialog Agent standard input text extractor version ${v}")
+  println("Enter plaintext for extraction, two blank lines to exit.")
 
-  // Read keyboard input until user hits [CTRL-D]
-  while (input.hasNextLine){
-    val extractions = engine.extractFrom(input.nextLine, keepText = true)
-    extractions.map(getExtraction).map(f => println(JsonUtils.writeJson(f)))
+  // Console input
+  val input:Scanner = new Scanner(System.in)
+
+  readInput(0)
+  println("\nExiting program...")
+
+  @tailrec
+  private def readInput(blankLines: Int): Unit = if(blankLines < 2) {
     print("\n> ")
+    val text: String = input.nextLine
+    if(text.isEmpty) {
+      readInput(blankLines + 1)
+    }
+    else {
+      val extractions = engine.extractFrom(text, keepText = true)
+      extractions.map(getExtraction).map(f => 
+        println(JsonUtils.writeJson(f))
+      )
+      readInput(0)
+    }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0"
+version in ThisBuild := "5.1.1"


### PR DESCRIPTION
Users can now gracefully exit the standard input Dialog Agent by entering two blank lines rather than using CTRL-D to interrupt SBT.
Version is now 5.1.1