### PR TITLE
master rule file selectable from the command line

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= {
 }
 
 // prevent sbt.TrapExitSecurityException being thrown under termination conditions
-trapExit := false
+//trapExit := false
 
 // Allow the DialogAgent to run in interactive mode
 connectInput in run := true

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,9 @@ libraryDependencies ++= {
   )
 }
 
+// prevent sbt.TrapExitSecurityException being thrown under termination conditions
+trapExit := false
+
 // Allow the DialogAgent to run in interactive mode
 connectInput in run := true
 

--- a/scripts/test_scripts/file_agent_testing/expected_results/expected.json
+++ b/scripts/test_scripts/file_agent_testing/expected_results/expected.json
@@ -124,7 +124,7 @@
     "sub_type": "Event:dialogue_event",
     "timestamp": "2022-05-01T22:54:01.441Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "topic": "agent/dialog"
 }
@@ -177,7 +177,7 @@
     "sub_type": "Event:dialogue_event",
     "timestamp": "2022-05-01T22:54:06.402Z",
     "trial_id": "0a11991f-fae4-4750-8ac5-af51d40273e3",
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "topic": "agent/dialog"
 }
@@ -210,7 +210,7 @@
       }
     ],
     "source": [
-      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:4.1.6"
+      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.1"
     ],
     "subscribes": [
       {
@@ -239,7 +239,7 @@
         "topic": "trial"
       }
     ],
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "header": {
     "message_type": "agent",
@@ -252,7 +252,7 @@
     "sub_type": "versioninfo",
     "timestamp": "2022-05-01T22:54:06.733Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "topic": "agent/tomcat_textAnalyzer/versioninfo"
 }
@@ -261,7 +261,7 @@
     "rollcall_id": "32352abb-be3f-4c51-bfdf-73660eee3453",
     "status": "up",
     "uptime": 5.615,
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "header": {
     "message_type": "agent",
@@ -274,7 +274,7 @@
     "sub_type": "rollcall:response",
     "timestamp": "2022-05-01T22:54:06.781Z",
     "trial_id": "8b37dcbf-8230-400c-8a0b-01b19b58a017",
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "topic": "agent/control/rollcall/response"
 }

--- a/scripts/test_scripts/file_agent_testing/expected_results/expected.json
+++ b/scripts/test_scripts/file_agent_testing/expected_results/expected.json
@@ -124,7 +124,7 @@
     "sub_type": "Event:dialogue_event",
     "timestamp": "2022-05-01T22:54:01.441Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "topic": "agent/dialog"
 }
@@ -177,7 +177,7 @@
     "sub_type": "Event:dialogue_event",
     "timestamp": "2022-05-01T22:54:06.402Z",
     "trial_id": "0a11991f-fae4-4750-8ac5-af51d40273e3",
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "topic": "agent/dialog"
 }
@@ -210,7 +210,7 @@
       }
     ],
     "source": [
-      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.1"
+      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.2"
     ],
     "subscribes": [
       {
@@ -239,7 +239,7 @@
         "topic": "trial"
       }
     ],
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "header": {
     "message_type": "agent",
@@ -252,7 +252,7 @@
     "sub_type": "versioninfo",
     "timestamp": "2022-05-01T22:54:06.733Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "topic": "agent/tomcat_textAnalyzer/versioninfo"
 }
@@ -261,7 +261,7 @@
     "rollcall_id": "32352abb-be3f-4c51-bfdf-73660eee3453",
     "status": "up",
     "uptime": 5.615,
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "header": {
     "message_type": "agent",
@@ -274,7 +274,7 @@
     "sub_type": "rollcall:response",
     "timestamp": "2022-05-01T22:54:06.781Z",
     "trial_id": "8b37dcbf-8230-400c-8a0b-01b19b58a017",
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "topic": "agent/control/rollcall/response"
 }

--- a/scripts/test_scripts/file_agent_testing/test_file_agent
+++ b/scripts/test_scripts/file_agent_testing/test_file_agent
@@ -34,7 +34,7 @@ cd ../../../../tomcat-text
 
 # Test the agent
 echo "Starting File Agent:"
-sbt "runMain org.clulab.asist.apps.RunDialogAgent file \
+sbt "runMain org.clulab.asist.apps.RunDialogAgent file --rulepath /org/clulab/asist/grammars/master.yml \
     $input_dir $results_metadata"
 
 cd $this_dir

--- a/scripts/test_scripts/mqtt_agent_testing/asr/dialog_agent_message_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/asr/dialog_agent_message_expected.json
@@ -124,6 +124,6 @@
     "sub_type": "Event:dialogue_event",
     "timestamp": "2022-04-23T21:59:23.534Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "4.1.6"
+    "version": "5.1.1"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/asr/dialog_agent_message_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/asr/dialog_agent_message_expected.json
@@ -124,6 +124,6 @@
     "sub_type": "Event:dialogue_event",
     "timestamp": "2022-04-23T21:59:23.534Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "5.1.1"
+    "version": "5.1.2"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/chat/dialog_agent_message_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/chat/dialog_agent_message_expected.json
@@ -47,6 +47,6 @@
     "sub_type": "Event:dialogue_event",
     "timestamp": "2022-04-23T21:56:33.747Z",
     "trial_id": "0a11991f-fae4-4750-8ac5-af51d40273e3",
-    "version": "4.1.6"
+    "version": "5.1.1"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/chat/dialog_agent_message_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/chat/dialog_agent_message_expected.json
@@ -47,6 +47,6 @@
     "sub_type": "Event:dialogue_event",
     "timestamp": "2022-04-23T21:56:33.747Z",
     "trial_id": "0a11991f-fae4-4750-8ac5-af51d40273e3",
-    "version": "5.1.1"
+    "version": "5.1.2"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/rollcall_request/rollcall_response_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/rollcall_request/rollcall_response_expected.json
@@ -3,7 +3,7 @@
     "rollcall_id": "6a845119-00d4-41ee-ad19-8e6603fe4318",
     "status": "up",
     "uptime": 466.285793,
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "header": {
     "message_type": "agent",
@@ -16,6 +16,6 @@
     "sub_type": "rollcall:response",
     "timestamp": "2022-03-24T19:20:59.678170Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "4.1.6"
+    "version": "5.1.1"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/test_mqtt_agent
+++ b/scripts/test_scripts/mqtt_agent_testing/test_mqtt_agent
@@ -22,7 +22,7 @@ function test_full_trial () {
 # Start the MQTT agent
 echo "Starting MQTT agent.   Testing will begin in 90 seconds"
 cd ../../../../tomcat-text
-sbt "runMain org.clulab.asist.apps.RunDialogAgent mqtt --host localhost --port 1883" &
+sbt "runMain org.clulab.asist.apps.RunDialogAgent mqtt --host localhost --port 1883 --rulepath /org/clulab/asist/grammars/master.yml" &
 mqtt_agent_pid="$!"
 
 sleep 90 # weaksauce, we need to detect a running agent 

--- a/scripts/test_scripts/mqtt_agent_testing/trial_start/heartbeat_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/trial_start/heartbeat_expected.json
@@ -15,6 +15,6 @@
     "sub_type": "heartbeat",
     "timestamp": "2022-04-23T21:54:57.220Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "4.1.6"
+    "version": "5.1.1"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/trial_start/heartbeat_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/trial_start/heartbeat_expected.json
@@ -15,6 +15,6 @@
     "sub_type": "heartbeat",
     "timestamp": "2022-04-23T21:54:57.220Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "5.1.1"
+    "version": "5.1.2"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/trial_start/version_info_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/trial_start/version_info_expected.json
@@ -27,7 +27,7 @@
       }
     ],
     "source": [
-      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.1"
+      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.2"
     ],
     "subscribes": [
       {
@@ -56,7 +56,7 @@
         "topic": "trial"
       }
     ],
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "header": {
     "message_type": "agent",
@@ -69,6 +69,6 @@
     "sub_type": "versioninfo",
     "timestamp": "2022-04-29T00:05:24.966Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "5.1.1"
+    "version": "5.1.2"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/trial_start/version_info_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/trial_start/version_info_expected.json
@@ -27,7 +27,7 @@
       }
     ],
     "source": [
-      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:4.1.6"
+      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.1"
     ],
     "subscribes": [
       {
@@ -56,7 +56,7 @@
         "topic": "trial"
       }
     ],
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "header": {
     "message_type": "agent",
@@ -69,6 +69,6 @@
     "sub_type": "versioninfo",
     "timestamp": "2022-04-29T00:05:24.966Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "4.1.6"
+    "version": "5.1.1"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/trial_stop/heartbeat_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/trial_stop/heartbeat_expected.json
@@ -14,6 +14,6 @@
     "source": "AC_UAZ_TA1_DialogAgent",
     "sub_type": "heartbeat",
     "timestamp": "2022-04-23T21:55:28.952Z",
-    "version": "4.1.6"
+    "version": "5.1.1"
   }
 }

--- a/scripts/test_scripts/mqtt_agent_testing/trial_stop/heartbeat_expected.json
+++ b/scripts/test_scripts/mqtt_agent_testing/trial_stop/heartbeat_expected.json
@@ -14,6 +14,6 @@
     "source": "AC_UAZ_TA1_DialogAgent",
     "sub_type": "heartbeat",
     "timestamp": "2022-04-23T21:55:28.952Z",
-    "version": "5.1.1"
+    "version": "5.1.2"
   }
 }

--- a/scripts/test_scripts/reprocessor_agent_testing/expected_results/expected.json
+++ b/scripts/test_scripts/reprocessor_agent_testing/expected_results/expected.json
@@ -129,7 +129,7 @@
       }
     ],
     "source": [
-      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:4.1.6"
+      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.1"
     ],
     "subscribes": [
       {
@@ -158,7 +158,7 @@
         "topic": "trial"
       }
     ],
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "header": {
     "message_type": "agent",
@@ -171,7 +171,7 @@
     "sub_type": "versioninfo",
     "timestamp": "2022-05-03T03:30:06.250Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "4.1.6"
+    "version": "5.1.1"
   },
   "topic": "agent/tomcat_textAnalyzer/versioninfo"
 }

--- a/scripts/test_scripts/reprocessor_agent_testing/expected_results/expected.json
+++ b/scripts/test_scripts/reprocessor_agent_testing/expected_results/expected.json
@@ -129,7 +129,7 @@
       }
     ],
     "source": [
-      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.1"
+      "https://gitlab.asist.aptima.com:5050/asist/testbed/AC_UAZ_TA1_DialogAgent:5.1.2"
     ],
     "subscribes": [
       {
@@ -158,7 +158,7 @@
         "topic": "trial"
       }
     ],
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "header": {
     "message_type": "agent",
@@ -171,7 +171,7 @@
     "sub_type": "versioninfo",
     "timestamp": "2022-05-03T03:30:06.250Z",
     "trial_id": "c38b02c2-7061-49d3-9f6a-66c002943b3f",
-    "version": "5.1.1"
+    "version": "5.1.2"
   },
   "topic": "agent/tomcat_textAnalyzer/versioninfo"
 }

--- a/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgent.scala
@@ -19,7 +19,7 @@ import scala.util.control.NonFatal
  */
 
 class DialogAgent (
-  val engine: TomcatRuleEngine = new TomcatRuleEngine
+  val ruleEngine: TomcatRuleEngine = new TomcatRuleEngine
 ) extends LazyLogging {
 
   // Used to compute agent uptime
@@ -28,7 +28,7 @@ class DialogAgent (
   // Run the rule engine to get its lazy init out of the way
   def startEngine(){
     logger.info("Initializing Extractor (this may take a few seconds) ...")
-    engine.extractFrom("I see a green victim")
+    ruleEngine.extractFrom("I see a green victim")
     logger.info("Extractor initialized.")
   }
 
@@ -45,22 +45,18 @@ class DialogAgent (
    * @param text String text to extract from, can be multiple sentences.
    * @return sequence of Odin Mentions
    */
-  def extractMentions(text: String): Seq[Mention] = {
-    engine
-      .extractFrom(Option(text).getOrElse(""), keepText = true)
-      .sortBy(m => (m.sentence, m.label))
-  }
+  def extractMentions(text: String): Seq[Mention] = ruleEngine
+    .extractFrom(Option(text).getOrElse(""), keepText = true)
+    .sortBy(m => (m.sentence, m.label))
 
   /**
    * Extract Odin mentions from text.
    * @param doc Document to extract from, can be multiple sentences.
    * @return sequence of Odin Mentions
    */
-  def extractMentions(doc: Document): Seq[Mention] = {
-    engine
-      .extractFrom(doc)
-      .sortBy(m => (m.sentence, m.label))
-  }
+  def extractMentions(doc: Document): Seq[Mention] = ruleEngine
+    .extractFrom(doc)
+    .sortBy(m => (m.sentence, m.label))
 
   /** Return an array of all extractions found in the input text
    *  @param text Text to analyze

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentFile.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentFile.scala
@@ -7,6 +7,8 @@ import com.typesafe.scalalogging.LazyLogging
 import java.io.{File, FileInputStream, PrintWriter}
 import org.clulab.asist.messages._
 import org.clulab.utils.LocalFileUtils
+import org.clulab.asist.extraction.TomcatRuleEngine
+
 
 import scala.annotation.tailrec
 import scala.io.Source
@@ -29,8 +31,10 @@ import scala.util.{Failure, Success}
 class DialogAgentFile(
   val inputFilename: String = "",
   val outputFilename: String = "",
-  val nochat: Boolean = false
-) extends DialogAgent with LazyLogging {
+  val nochat: Boolean = false,
+  override val ruleEngine: TomcatRuleEngine = new TomcatRuleEngine
+
+) extends DialogAgent(ruleEngine) with LazyLogging {
 
   // get rule engine lazy init out of the way
   startEngine()

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -99,7 +99,7 @@ class DialogAgentMqtt(
     publishedTraffic += topic
   }
 
-  /** Write the message to the message bus topic
+  /** Write the message to the message bus topic.  Do not publish the topic
    * @param message:  Any of our published messages
    */
   def publish[A <: AnyRef](message: A): Unit = message match {

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentMqtt.scala
@@ -7,6 +7,8 @@ import com.typesafe.scalalogging.LazyLogging
 import java.time.Clock
 import org.clulab.asist.messages._
 import org.clulab.utils.{MessageBusClient, MessageBusClientListener}
+import org.clulab.asist.extraction.TomcatRuleEngine
+
 
 import scala.collection.mutable.MutableList
 import scala.collection.mutable.Queue
@@ -29,8 +31,9 @@ import scala.language.postfixOps
 class DialogAgentMqtt(
   val host: String = "localhost",
   val port: Int = 1883,
-  val nochat: Boolean = false
-) extends DialogAgent
+  val nochat: Boolean = false,
+  override val ruleEngine: TomcatRuleEngine = new TomcatRuleEngine
+) extends DialogAgent(ruleEngine)
     with LazyLogging
     with MessageBusClientListener { 
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentReprocessor.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentReprocessor.scala
@@ -6,6 +6,7 @@ import java.nio.file.Paths
 import java.time.Clock
 import org.clulab.asist.messages._
 import org.clulab.utils.LocalFileUtils
+import org.clulab.asist.extraction.TomcatRuleEngine
 import org.json4s.{Extraction,_}
 
 import scala.annotation.tailrec
@@ -48,7 +49,9 @@ class DialogAgentReprocessor (
   val inputDirName: String = "",
   val outputDirName: String = "",
   val ta3Version: Option[Int] = None,
-) extends DialogAgent with LazyLogging {
+  override val ruleEngine: TomcatRuleEngine = new TomcatRuleEngine
+
+) extends DialogAgent(ruleEngine) with LazyLogging {
 
   logger.info(s"DialogAgentReprocessor version ${BuildInfo.version} running")
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
@@ -2,6 +2,8 @@ package org.clulab.asist.agents
 
 import buildinfo.BuildInfo
 import java.util.Scanner
+import org.clulab.asist.extraction.TomcatRuleEngine
+
 
 /**
  *  Authors:  Joseph Astier, Adarsh Pyarelal, Rebecca Sharp
@@ -11,7 +13,9 @@ import java.util.Scanner
  *
  */
 
-class DialogAgentStdin extends DialogAgent { 
+class DialogAgentStdin (
+  override val engine: TomcatRuleEngine = new TomcatRuleEngine
+) extends DialogAgent(engine) { 
 
   // get rule engine lazy init out of the way
   startEngine()

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentStdin.scala
@@ -14,8 +14,8 @@ import org.clulab.asist.extraction.TomcatRuleEngine
  */
 
 class DialogAgentStdin (
-  override val engine: TomcatRuleEngine = new TomcatRuleEngine
-) extends DialogAgent(engine) { 
+  override val ruleEngine: TomcatRuleEngine = new TomcatRuleEngine
+) extends DialogAgent(ruleEngine) { 
 
   // get rule engine lazy init out of the way
   startEngine()
@@ -37,7 +37,7 @@ class DialogAgentStdin (
       blankLines += 1
     }
     else {
-      val extractions = engine.extractFrom(text, keepText = true)
+      val extractions = ruleEngine.extractFrom(text, keepText = true)
       extractions.map(getExtraction).map(f => 
         println(JsonUtils.writeJson(f))
       )

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -49,10 +49,10 @@ object RunDialogAgent extends App with LazyLogging {
     ta3_version: Option[Int] = None,
 
     // rule base 
-    rules: String = masterRulesPath
+    rulepath: String = masterRulesPath
   )
 
-  val rules_hint: String = 
+  val rulepath_hint: String = 
     s"Optional rule base path. Defaults to ${masterRulesPath} if not set"
 
   val ta3_hint: String = """Optional TA3 version number for reprocessed files.  
@@ -77,10 +77,10 @@ Existing TA3 version numbers are incremented by 1 if not set"""
         opt[Unit]("nochat")
           .action((_, c) => c.copy(nochat = true))
           .text("Optional flag to exclude Minecraft Chat messages"),
-        opt[String]("rules")
+        opt[String]("rulepath")
           .valueName("<String>")
-          .action((x, c) => c.copy(rules = x))
-          .text(rules_hint)
+          .action((x, c) => c.copy(rulepath = x))
+          .text(rulepath_hint)
         )
     cmd("file")
       .action((_, c) => c.copy(agent = "file"))
@@ -96,18 +96,18 @@ Existing TA3 version numbers are incremented by 1 if not set"""
         opt[Unit]("nochat")
           .action((_, c) => c.copy(nochat = true))
           .text("Optional flag to exclude Minecraft Chat messages"),
-        opt[String]("rules")
+        opt[String]("rulepath")
           .valueName("<String>")
-          .action((x, c) => c.copy(rules = x))
-          .text(rules_hint)
+          .action((x, c) => c.copy(rulepath = x))
+          .text(rulepath_hint)
         )
     cmd("stdin")
       .action((_, c) => c.copy(agent = "stdin"))
       .children(
-        opt[String]("rules")
+        opt[String]("rulepath")
           .valueName("<String>")
-          .action((x, c) => c.copy(rules = x))
-          .text(rules_hint)
+          .action((x, c) => c.copy(rulepath = x))
+          .text(rulepath_hint)
         )
     cmd("reprocess")
       .action((_, c) => c.copy(agent = "reprocess"))
@@ -124,10 +124,10 @@ Existing TA3 version numbers are incremented by 1 if not set"""
           .valueName("<Int>")
           .action((x, c) => c.copy(ta3_version = Some(x)))
           .text(ta3_hint),
-        opt[String]("rules")
+        opt[String]("rulepath")
           .valueName("<String>")
-          .action((x, c) => c.copy(rules = x))
-          .text(rules_hint)
+          .action((x, c) => c.copy(rulepath = x))
+          .text(rulepath_hint)
         )
   }
 

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -1,6 +1,8 @@
 package org.clulab.asist.apps
 
 import com.typesafe.scalalogging.LazyLogging
+import org.clulab.asist.extraction.TomcatRuleEngine
+
 import org.clulab.asist.agents._
 import scopt.OParser
 import buildinfo.BuildInfo
@@ -159,7 +161,7 @@ Existing TA3 version numbers are incremented by 1 if not set"""
       )
     case "stdin" =>
       logger.info("Starting Stdin agent...")
-      new DialogAgentStdin
+      new DialogAgentStdin(new TomcatRuleEngine(rulepath = Some(arguments.rulepath)))
     case _ =>
       logger.error(f"Could not run agent '${arguments.agent}'")
       logger.error("valid agent types are [mqtt, reprocess, stdin, file]")

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -141,14 +141,24 @@ Existing TA3 version numbers are incremented by 1 if not set"""
         logger.info("Starting MQTT agent...")
         logger.info("  host: " + arguments.host) 
         logger.info("  port: " + arguments.port) 
-        if(arguments.nochat) logger.info("Minecraft Chat messages not processed")
-        new DialogAgentMqtt(arguments.host, arguments.port, arguments.nochat, ruleEngine)
+        if(arguments.nochat) logger.info("Chat messages not processed")
+        new DialogAgentMqtt(
+          arguments.host,
+          arguments.port,
+          arguments.nochat,
+          ruleEngine
+        )
       case "file" =>
         logger.info("Starting File agent...")
         logger.info("  input: " + arguments.src) 
         logger.info("  output file: " + arguments.dst) 
-        if(arguments.nochat) logger.info("Minecraft Chat messages not processed")
-        new DialogAgentFile(arguments.src, arguments.dst, arguments.nochat, ruleEngine)
+        if(arguments.nochat) logger.info("Chat messages not processed")
+        new DialogAgentFile(
+          arguments.src,
+          arguments.dst,
+          arguments.nochat, 
+          ruleEngine
+        )
       case "reprocess" =>
         logger.info("Starting Reprocessor agent...")
         logger.info("  input dir: " + arguments.src) 

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -134,37 +134,41 @@ Existing TA3 version numbers are incremented by 1 if not set"""
   }
 
   // Run the appropriate agent for the given arguments
-  def run(arguments: Arguments): Unit = arguments.agent match {
-    case "mqtt" =>
-      logger.info("Starting MQTT agent...")
-      logger.info("  host: " + arguments.host) 
-      logger.info("  port: " + arguments.port) 
-      if(arguments.nochat) logger.info("Minecraft Chat messages not processed")
-      new DialogAgentMqtt(arguments.host, arguments.port, arguments.nochat)
-    case "file" =>
-      logger.info("Starting File agent...")
-      logger.info("  input: " + arguments.src) 
-      logger.info("  output file: " + arguments.dst) 
-      if(arguments.nochat) logger.info("Minecraft Chat messages not processed")
-      new DialogAgentFile(arguments.src, arguments.dst, arguments.nochat)
-    case "reprocess" =>
-      logger.info("Starting Reprocessor agent...")
-      logger.info("  input dir: " + arguments.src) 
-      logger.info("  output dir: " + arguments.dst) 
-      arguments.ta3_version.foreach(v => 
-        logger.info("  ta3 version: " + v)
-      )
-      new DialogAgentReprocessor(
-        arguments.src,
-        arguments.dst,
-        arguments.ta3_version
-      )
-    case "stdin" =>
-      logger.info("Starting Stdin agent...")
-      new DialogAgentStdin(new TomcatRuleEngine(rulepath = Some(arguments.rulepath)))
-    case _ =>
-      logger.error(f"Could not run agent '${arguments.agent}'")
-      logger.error("valid agent types are [mqtt, reprocess, stdin, file]")
+  def run(arguments: Arguments): Unit = {
+    val ruleEngine = new TomcatRuleEngine(rulepath = Some(arguments.rulepath))
+    arguments.agent match {
+      case "mqtt" =>
+        logger.info("Starting MQTT agent...")
+        logger.info("  host: " + arguments.host) 
+        logger.info("  port: " + arguments.port) 
+        if(arguments.nochat) logger.info("Minecraft Chat messages not processed")
+        new DialogAgentMqtt(arguments.host, arguments.port, arguments.nochat, ruleEngine)
+      case "file" =>
+        logger.info("Starting File agent...")
+        logger.info("  input: " + arguments.src) 
+        logger.info("  output file: " + arguments.dst) 
+        if(arguments.nochat) logger.info("Minecraft Chat messages not processed")
+        new DialogAgentFile(arguments.src, arguments.dst, arguments.nochat, ruleEngine)
+      case "reprocess" =>
+        logger.info("Starting Reprocessor agent...")
+        logger.info("  input dir: " + arguments.src) 
+        logger.info("  output dir: " + arguments.dst) 
+        arguments.ta3_version.foreach(v => 
+          logger.info("  ta3 version: " + v)
+        )
+        new DialogAgentReprocessor(
+          arguments.src,
+          arguments.dst,
+          arguments.ta3_version,
+          ruleEngine
+        )
+      case "stdin" =>
+        logger.info("Starting Stdin agent...")
+        new DialogAgentStdin(ruleEngine)
+      case _ =>
+        logger.error(f"Could not run agent '${arguments.agent}'")
+        logger.error("valid agent types are [mqtt, reprocess, stdin, file]")
+    }
   }
 
   // Run the arguments if parsing was successful

--- a/src/main/scala/org/clulab/asist/extraction/TomcatRuleEngine.scala
+++ b/src/main/scala/org/clulab/asist/extraction/TomcatRuleEngine.scala
@@ -16,6 +16,7 @@ class TomcatRuleEngine(
 
   val proc: Processor = new FastNLPProcessor() // TODO: Get from configuration file soon
 
+
   override def getConf: Config = config
 
   protected def getFullName(name: String): String = TomcatRuleEngine.PREFIX + "." + name
@@ -37,9 +38,6 @@ class TomcatRuleEngine(
     )
     val taxonomyPath: String =
       getPath("taxonomyPath", "/org/clulab/asist/grammars/taxonomy.yml")
-
-  logger.info("LoadableAttributes:");
-  logger.info(s"masterRulesPath: ${masterRulesPath}");
 
     def apply(): LoadableAttributes = {
       // Reread these values from their files/resources each time based on paths in the config file.

--- a/src/main/scala/org/clulab/asist/extraction/TomcatRuleEngine.scala
+++ b/src/main/scala/org/clulab/asist/extraction/TomcatRuleEngine.scala
@@ -1,5 +1,7 @@
 package org.clulab.asist.extraction
 
+import com.typesafe.scalalogging.LazyLogging
+
 import com.typesafe.config.{Config, ConfigFactory}
 import org.clulab.odin.{ExtractorEngine, Mention, State}
 import org.clulab.processors.fastnlp.FastNLPProcessor
@@ -7,7 +9,10 @@ import org.clulab.processors.{Document, Processor}
 import org.clulab.utils.{Configured, FileUtils}
 import org.slf4j.{Logger, LoggerFactory}
 
-class TomcatRuleEngine(val config: Config = ConfigFactory.load()) extends Configured {
+class TomcatRuleEngine(
+  val config: Config = ConfigFactory.load(),
+  val rulepath: Option[String] = None
+) extends Configured with LazyLogging {
 
   val proc: Processor = new FastNLPProcessor() // TODO: Get from configuration file soon
 
@@ -21,6 +26,8 @@ class TomcatRuleEngine(val config: Config = ConfigFactory.load()) extends Config
     path
   }
 
+  rulepath.foreach(path => logger.info(s"rulepath = ${path}"))
+
   // These are the values which can be reloaded.  Query them for current assignments.
   class LoadableAttributes(val actions: TomcatActions, val engine: ExtractorEngine)
 
@@ -29,6 +36,9 @@ class TomcatRuleEngine(val config: Config = ConfigFactory.load()) extends Config
       getPath("masterRulesPath", "/org/clulab/asist/grammars/master.yml")
     val taxonomyPath: String =
       getPath("taxonomyPath", "/org/clulab/asist/grammars/taxonomy.yml")
+
+  logger.info("LoadableAttributes:");
+  logger.info(s"masterRulesPath: ${masterRulesPath}");
 
     def apply(): LoadableAttributes = {
       // Reread these values from their files/resources each time based on paths in the config file.
@@ -43,6 +53,7 @@ class TomcatRuleEngine(val config: Config = ConfigFactory.load()) extends Config
   }
 
   var loadableAttributes = LoadableAttributes()
+
 
   // These public variables are accessed directly by clients which
   // don't know they are loadable and which had better not keep copies.

--- a/src/main/scala/org/clulab/asist/extraction/TomcatRuleEngine.scala
+++ b/src/main/scala/org/clulab/asist/extraction/TomcatRuleEngine.scala
@@ -32,8 +32,9 @@ class TomcatRuleEngine(
   class LoadableAttributes(val actions: TomcatActions, val engine: ExtractorEngine)
 
   object LoadableAttributes {
-    val masterRulesPath: String =
+    val masterRulesPath: String = rulepath.getOrElse(
       getPath("masterRulesPath", "/org/clulab/asist/grammars/master.yml")
+    )
     val taxonomyPath: String =
       getPath("taxonomyPath", "/org/clulab/asist/grammars/taxonomy.yml")
 

--- a/src/main/scala/org/clulab/asist/messages/VersionInfoMessage.scala
+++ b/src/main/scala/org/clulab/asist/messages/VersionInfoMessage.scala
@@ -24,7 +24,7 @@ case class VersionInfoMessageDataConfig(
 )
 
 // Part of the VersionInfoMessage class 
-case class VersionInfoMessageDataTopic(
+case class VersionInfoChannel(
   topic: String = "N/A",
   message_type: String = "N/A",
   sub_type: String = "N/A",
@@ -38,8 +38,8 @@ case class VersionInfoMessageData(
   source: Seq[String] = List(),
   dependencies: Seq[String] = List(),
   config: Seq[VersionInfoMessageDataConfig] = List(),
-  publishes: Seq[VersionInfoMessageDataTopic] = List(),
-  subscribes: Seq[VersionInfoMessageDataTopic] = List()
+  publishes: Seq[VersionInfoChannel] = List(),
+  subscribes: Seq[VersionInfoChannel] = List()
 )
 
 // published on the Message Bus
@@ -77,49 +77,49 @@ object VersionInfoMessage
     dependencies = List(),
     config = List(),
     publishes = List(
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("DialogAgent.topic"),
         config.getString("DialogAgent.header.message_type"),
         config.getString("DialogAgent.msg.sub_type")
       ),
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("Heartbeat.topic"),
         config.getString("Heartbeat.header.message_type"),
         config.getString("Heartbeat.msg.sub_type")
       ),
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("RollcallResponse.topic"),
         config.getString("RollcallResponse.header.message_type"),
         config.getString("RollcallResponse.msg.sub_type")
       ),
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("VersionInfo.topic"),
         config.getString("VersionInfo.header.message_type"),
         config.getString("VersionInfo.msg.sub_type")
       )
     ),
     subscribes = List(
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("Asr.topic"),
         config.getString("Asr.header.message_type"),
         config.getString("Asr.msg.sub_type")
       ),
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("Chat.topic"),
         config.getString("Chat.header.message_type"),
         config.getString("Chat.msg.sub_type")
       ),
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("RollcallRequest.topic"),
         config.getString("RollcallRequest.header.message_type"),
         config.getString("RollcallRequest.msg.sub_type")
       ),
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("Trial.topic"),
         config.getString("Trial.header.message_type"),
         config.getString("Trial.msg.sub_type.trial_start")
       ),
-      VersionInfoMessageDataTopic(
+      VersionInfoChannel(
         config.getString("Trial.topic"),
         config.getString("Trial.header.message_type"),
         config.getString("Trial.msg.sub_type.trial_stop")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.1"
+version in ThisBuild := "5.1.2"


### PR DESCRIPTION
- The file for the Dialog Agent Rule Engine can be set with with the "--rulepath" command line argument.  
- The rule path is in the same format as in the config file, e.g. "/org/clulab/asist/grammars/master.yml"
- If the argument is not set, the file specified in the config file is used.

