### PR TITLE
Cleaner shutdown if rulepath not found

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,9 +43,6 @@ libraryDependencies ++= {
   )
 }
 
-// prevent sbt.TrapExitSecurityException being thrown under termination conditions
-//trapExit := false
-
 // Allow the DialogAgent to run in interactive mode
 connectInput in run := true
 


### PR DESCRIPTION
The Agent will now exit the JVM with error code 1 if the '--rulepath' arg is not found.