### PR TITLE
Rest api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches: [ '*' ]
 
+runs:
+  using: 'node16'
+  main: 'main.js'
+
 jobs:
   build:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ on:
   pull_request:
     branches: [ '*' ]
 
-runs:
-  using: 'node16'
-  main: 'main.js'
-
 jobs:
   build:
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -43,9 +43,6 @@ DialogAgent {
   // Directory to write the reprocessed .metadata files to
   outputDir = "reprocessed_output"
 
-  // URL for the Texas A&M University Dialogue Act Classifier service
-  dacServerURL = "http://localhost:8000"
-
   // published fields
   topic = "agent/dialog"
   header{

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -30,6 +30,13 @@ CommonMsg{
 
 // Options for the DialogAgent message
 DialogAgent {
+
+  // REST API vars
+  restApiServer {
+    host = "localhost"
+    port = 8080
+  }
+
   // Directory containing .metadata files to reprocess
   inputDir = ""
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentRestApi.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentRestApi.scala
@@ -14,10 +14,6 @@ import scala.concurrent.{ExecutionContext,Future}
 import org.clulab.asist.extraction.TomcatRuleEngine
 import org.clulab.asist.messages.DialogAgentMessageUtteranceExtraction
 
-// needed?  
-//import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-//import spray.json.DefaultJsonProtocol._
-
 // Process HTTP requests containing text spans
 // Generate HTTP responses with extractions
 

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentRestApi.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentRestApi.scala
@@ -1,0 +1,23 @@
+package org.clulab.asist.agents
+
+import buildinfo.BuildInfo
+import org.clulab.asist.extraction.TomcatRuleEngine
+
+
+// Process HTTP requests containing text spans
+// Generate HTTP responses with extractions
+
+class DialogAgentRestApi (
+  override val ruleEngine: TomcatRuleEngine = new TomcatRuleEngine
+) extends DialogAgent(ruleEngine) {
+
+  logger.info(s"DialogAgentRestApi version ${BuildInfo.version} running.")
+
+  // get rule engine lazy init out of the way
+  startEngine()
+
+  // REST API main loop
+
+  println("Exiting Dialog Agent REST API")
+}
+

--- a/src/main/scala/org/clulab/asist/agents/DialogAgentRestApi.scala
+++ b/src/main/scala/org/clulab/asist/agents/DialogAgentRestApi.scala
@@ -8,6 +8,8 @@ import akka.http.scaladsl.model._
 import scala.concurrent.ExecutionContext
 
 import buildinfo.BuildInfo
+import com.typesafe.config.Config
+import ai.lum.common.ConfigFactory
 import org.clulab.asist.extraction.TomcatRuleEngine
 
 // Process HTTP requests containing text spans
@@ -18,6 +20,11 @@ class DialogAgentRestApi (
   override val ruleEngine: TomcatRuleEngine = new TomcatRuleEngine
 ) extends DialogAgent(ruleEngine) {
 
+  private val config: Config = ConfigFactory.load()
+
+  val host = config.getString("DialotAgent.restApiServer.host")
+  val port = config.getInt("RollcallRequest.restApiServer.port")
+
   logger.info(s"DialogAgentRestApi version ${BuildInfo.version} starting...")
 
   // get rule engine lazy init out of the way
@@ -26,8 +33,6 @@ class DialogAgentRestApi (
   implicit val system = ActorSystem("DialogAgentRestApi")
   implicit val executionContext = ExecutionContext.global
 
-  val host = "localhost"
-  val port = 8080
 
     val requestHandler: HttpRequest => HttpResponse = {
 

--- a/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
+++ b/src/main/scala/org/clulab/asist/apps/RunDialogAgent.scala
@@ -111,6 +111,14 @@ Existing TA3 version numbers are incremented by 1 if not set"""
           .action((x, c) => c.copy(rulepath = x))
           .text(rulepath_hint)
         )
+    cmd("rest")
+      .action((_, c) => c.copy(agent = "rest"))
+      .children(
+        opt[String]("rulepath")
+          .valueName("<String>")
+          .action((x, c) => c.copy(rulepath = x))
+          .text(rulepath_hint)
+        )
     cmd("reprocess")
       .action((_, c) => c.copy(agent = "reprocess"))
       .children(
@@ -175,9 +183,12 @@ Existing TA3 version numbers are incremented by 1 if not set"""
       case "stdin" =>
         logger.info("Starting Stdin agent...")
         new DialogAgentStdin(ruleEngine)
+      case "rest" =>
+        logger.info("Starting REST API agent...")
+        new DialogAgentRestApi(ruleEngine)
       case _ =>
         logger.error(f"Could not run agent '${arguments.agent}'")
-        logger.error("valid agent types are [mqtt, reprocess, stdin, file]")
+        logger.error("valid agent types are [file, mqtt, rest, reprocess, stdin]")
     }
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.2"
+version in ThisBuild := "5.2.0"


### PR DESCRIPTION
# Dialog Agent REST API

The Dialog Agent can be run as a REST API server.   Extractions are generated from plaintext input via HTTP POST request, and return as a JSON string.

The server URL is currently http://localhost:8080, with the host and port defined in 
tomcat-text/src/main/resources/application.conf

## Starting the Agent 
    sbt "runMain org.clulab.asist.apps.RunDialogAgent rest"

The base rule path can be specified with the '--rulepath' argument.  The default rule path is ```/org/clulab/asist/grammars/master.yml``` if this argument is not set.



## Creating extractions
Send an HTTP POST request to http://localhost:8080 with a plaintext string as the data.  The agent will return the extractions in JSON format as a single line of text.

### Example
input:

    curl -d 'I see you' -X POST http://localhost:8080

output:
``` json
[{"arguments":{"target":[{"attachments":[],"end_offset":9,"labels":["You","Entity","Concept"],"rule":"you_token_capture","span":"you","start_offset":6}]},"attachments":[{"agentType":"Self","labels":["Self","Entity","Concept"],"span":[0],"text":"I"}],"end_offset":9,"labels":["Sight","SimpleAction","Action","EventLike","Concept"],"rule":"lemma_verb_dobj-sight_entity","span":"see you","start_offset":2}]
```

## Checking the agent status
Send an HTTP GET request to http://localhost:8080/status.   If the agent is running it will return a message with the uptime in seconds.

### Example
input:

    curl http://localhost:8080/status

output:

    Dialog Agent REST API has been running for 123.456 seconds